### PR TITLE
change the life of leeks in the reports to 0hp when they are dead

### DIFF
--- a/src/component/report/report.vue
+++ b/src/component/report/report.vue
@@ -400,9 +400,9 @@
 				if (!leek.leek.summon) {
 					const data = []
 					for (let j = 0; j <= this.fight.report.duration; j++) {
-						let life = Math.max(1, this.statistics.life[j][i])
+						let life = this.statistics.life[j][i]
 						if (this.log) {
-							life = Math.log2(life)
+							life = Math.log2(Math.max(1, life))
 						}
 						data.push(life)
 					}


### PR DESCRIPTION
The chart showing the evolution of hp was showing 1hp for dead leeks instead of 0 in it's non-logarithmic version.