### PR TITLE
Fix trophies stats bar overflow

### DIFF
--- a/src/component/trophies/trophies.vue
+++ b/src/component/trophies/trophies.vue
@@ -201,7 +201,6 @@
 		}
 	}
 	.category-bar-wrapper {
-		width: 70%;
 		text-align: right;
 		white-space: nowrap;
 		.stats {


### PR DESCRIPTION
Hi,

This commit fixes an overflow I encountered on trophies completion progression bar.

Before:
![before](https://user-images.githubusercontent.com/18068904/94339319-71d5d480-fff9-11ea-8e55-2786899c917f.png)

After:
![after](https://user-images.githubusercontent.com/18068904/94339321-74d0c500-fff9-11ea-9fc2-838d21e9a1e3.png)

I removed the width to allow flex containers resize. I validated this on
- Mozilla Firefox 80.0.1
- Chromium 85.0.4183.83
