### PR TITLE
Fix toast message on team creation error

### DIFF
--- a/src/component/farmer/farmer.vue
+++ b/src/component/farmer/farmer.vue
@@ -646,7 +646,7 @@
 				team.opened = true
 				store.commit('create-team', team)
 			}).error(error => {
-				LeekWars.toast(this.$i18n.t(error))
+				LeekWars.toast(this.$i18n.t(error.error))
 			})
 		}
 		cancelCandidacy() {


### PR DESCRIPTION
Replaces bad json serialization "[object Object]" to proper message
"team_already_used" or "Nom d'équipe déjà utilisé".

edit: I found some other places where this occurs (e.g. ban owner of team reject message)