### PR TITLE
Fix number of topics/messages of a forum catgory

### DIFF
--- a/src/component/forum/forum.vue
+++ b/src/component/forum/forum.vue
@@ -56,13 +56,13 @@
 							<div class="description">{{ $t('team_forum_description') }}</div>
 						</div>
 						<div v-if="LeekWars.mobile" class="mobile-info">
-							<span>{{ $t('n_topics', [LeekWars.formatNumber(category.topics)]) }}</span>
+							<span>{{ $t('n_topics', [LeekWars.formatNumber(category.topics || 0)]) }}</span>
 							•
-							<span>{{ $t('n_messages', [LeekWars.formatNumber(category.messages)]) }}</span>
+							<span>{{ $t('n_messages', [LeekWars.formatNumber(category.messages || 0)]) }}</span>
 						</div>
 					</div>
-					<div v-if="!LeekWars.mobile" class="num-topics">{{ category.topics | number }}</div>
-					<div v-if="!LeekWars.mobile" class="num-messages">{{ category.messages | number }}</div>
+					<div v-if="!LeekWars.mobile" class="num-topics">{{ category.topics || 0 | number }}</div>
+					<div v-if="!LeekWars.mobile" class="num-messages">{{ category.messages || 0 | number }}</div>
 				</router-link>
 			</template>
 		</panel>


### PR DESCRIPTION
This displays "0" as a replacement of "null" for a default value.

Before:
![2020-09-27-164401_351x109_scrot](https://user-images.githubusercontent.com/18068904/94367713-ba1bf200-00e0-11eb-9fc0-11f064bc3251.png)

After:
![2020-09-27-164349_528x136_scrot](https://user-images.githubusercontent.com/18068904/94367715-bbe5b580-00e0-11eb-99ee-464f2b255c68.png)


Maybe it should be fixed server-side?