### PR TITLE
Fix forum breadcrumb vertical alignment

### DIFF
--- a/src/component/forum/breadcrumb.vue
+++ b/src/component/forum/breadcrumb.vue
@@ -19,7 +19,6 @@
 <style lang="scss" scoped>
 	.breadcrumb {
 		display: flex;
-		align-items: baseline;
 		margin: 0 -6px;
 		height: 100%;
 		.item {


### PR DESCRIPTION
Hi,

On firefox I noticed a veritcal disalignement on forum breadcrumb. This commit tries to fix it by removing an unecessary flex baseline alignment property. It works fine with and without on Chromium.

Before:
![2020-09-27-165938_279x87_scrot](https://user-images.githubusercontent.com/18068904/94368137-ffd9ba00-00e2-11eb-8e92-c43d109f32c8.png)

After:
![2020-09-27-165951_275x83_scrot](https://user-images.githubusercontent.com/18068904/94368141-05370480-00e3-11eb-81f1-58591b942c64.png)
