### PR TITLE
Add shortcut to save all IAs at once in the editor

### DIFF
--- a/src/component/editor/editor.vue
+++ b/src/component/editor/editor.vue
@@ -214,6 +214,7 @@
 
 				<ul class="shortcuts">
 					<li v-html="$t('shortcut.shortcut_1')"></li>
+					<li v-html="$t('shortcut.shortcut_13')"></li>
 					<li v-html="$t('shortcut.shortcut_2')"></li>
 					<li v-html="$t('shortcut.shortcut_3')"></li>
 					<li v-html="$t('shortcut.shortcut_4')"></li>

--- a/src/component/editor/editor.vue
+++ b/src/component/editor/editor.vue
@@ -528,6 +528,7 @@
 
 		beforeDestroy() {
 			this.$root.$off('ctrlS')
+			this.$root.$off('ctrlShiftS')
 			this.$root.$off('ctrlQ')
 			this.$root.$off('ctrlF')
 			this.$root.$off('ctrlP')

--- a/src/component/tutorial/tutorial.vue
+++ b/src/component/tutorial/tutorial.vue
@@ -141,6 +141,7 @@
 				<p>{{ $t('editor_8') }}
 					<ul>
 						<li v-html="$t('shortcut.shortcut_1')"></li>
+						<li v-html="$t('shortcut.shortcut_13')"></li>
 						<li v-html="$t('shortcut.shortcut_2')"></li>
 						<li v-html="$t('shortcut.shortcut_3')"></li>
 						<li v-html="$t('shortcut.shortcut_4')"></li>

--- a/src/lang/en/shortcut.json
+++ b/src/lang/en/shortcut.json
@@ -1,5 +1,6 @@
 {
 	"shortcut_1": "<b>Ctrl + S</b>: save the current AI",
+	"shortcut_13": "<b>Ctrl + Shift + S</b> : save all active AIs",
 	"shortcut_2": "<b>Ctrl + Q</b>: run a test",
 	"shortcut_3": "<b>Ctrl + D</b>: duplicate the line or the selected text",
 	"shortcut_4": "<b>Ctrl + K</b>: delete the current line",

--- a/src/lang/fr/shortcut.json
+++ b/src/lang/fr/shortcut.json
@@ -1,5 +1,6 @@
 {
 	"shortcut_1": "<b>Ctrl + S</b> : sauvegarder l'IA courante",
+	"shortcut_13": "<b>Ctrl + Shift + S</b> : sauvegarder toutes les IAs actives",
 	"shortcut_2": "<b>Ctrl + Q</b> : lancer un test",
 	"shortcut_3": "<b>Ctrl + D</b> : dupliquer la ligne ou la sélection courante",
 	"shortcut_4": "<b>Ctrl + K</b> : supprimer la ligne courante",

--- a/src/model/vue.ts
+++ b/src/model/vue.ts
@@ -227,8 +227,10 @@ const vueMain = new Vue({
 	},
 	created() {
 		window.addEventListener('keydown', (event) => {
-			this.$emit('keydown', event)
-			if (event.ctrlKey && event.keyCode === 83) {
+			this.$emit('keydown', event) 
+			if (event.ctrlKey && event.shiftKey && event.keyCode === 83) {
+				this.$emit('ctrlShiftS')
+			} else if (event.ctrlKey && event.keyCode === 83) {
 				this.$emit('ctrlS')
 				event.preventDefault()
 			} else if (event.ctrlKey && event.keyCode === 81) {


### PR DESCRIPTION
I added the shortcut ctrl + shift + S to the editor, which allow saving of all active IAs at once.
I added the shortcut information in the editor settings panel and in the tutorial page.

I'm not familiar with TypeScript nor Vue.js, so i mostly copied what was already there and did minor modifications.
I didn't wanted to create duplicated code, so i added a parameter to 'EditorPage.save' and 'EditorPage.test' functions. I added the parameter used in the original functions to the already defined references.
Otherwise it's just a loop, that call the method 'save' for each 'AIView'.