### PR TITLE
[Fix] Empty team fight history

### DIFF
--- a/src/component/history/history.vue
+++ b/src/component/history/history.vue
@@ -118,7 +118,8 @@
 						(this.displayTypes.solo && fight.type === FightType.SOLO) ||
 						(this.displayTypes.farmer && fight.type === FightType.FARMER) ||
 						(this.displayTypes.team && fight.type === FightType.TEAM) ||
-						(this.displayTypes.battleRoyale && fight.type === FightType.BATTLE_ROYALE)
+						(this.displayTypes.battleRoyale && fight.type === FightType.BATTLE_ROYALE) ||
+                        this.type === 'team'
 					)
 			})
 		}


### PR DESCRIPTION
The team fight history was empty when, on an other history, the "Team" checkbox was not checked.
To reproduce the bug:
- Go to a leek or farmer history (example: https://leekwars.com/farmer/48992/history)
- Uncheck "Team"
- Go to a team history (example: https://leekwars.com/team/6132/history)
- The history is empty

Forum topic : https://leekwars.com/forum/category-3/topic-10322