### PR TITLE
Descrete icons in help page

### DIFF
--- a/src/sfw.scss
+++ b/src/sfw.scss
@@ -36,7 +36,7 @@
 	.panel .header .right .button:hover {
 		color: black;
 	}
-	img, svg {
+	img, svg, i {
 		opacity: 0.08;
 	}
 	.smiley, .hab, .crystal {


### PR DESCRIPTION
Applies opacity for icons in descrete mode.
fixes #617 