### PR TITLE
Update tournament.vue

### DIFF
--- a/src/component/tournament/tournament.vue
+++ b/src/component/tournament/tournament.vue
@@ -308,6 +308,7 @@ Max power: {{ tournament.max_power | number }}
 	}
 	.tooltip {
 		transform: translate(-50%, 0px);
+		z-index: 1;
 	}
 	.tournament.zoomed {
 		overflow-x: auto;


### PR DESCRIPTION
Affiche le tooltip au-dessus de la barre de titre "Commentaires".
fixes #507 