### PR TITLE
Ajout d'un décalage pour le détail des puces dans l'éditeur

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -55,6 +55,9 @@
 .v-tooltip__content.fluid {
 	max-width: none !important;
 }
+.menuable__content__active {
+	transform: translateX(20px);
+}
 .v-dialog {
 	margin: 12px !important;
 }


### PR DESCRIPTION
fix #641

Finalement un décalage de 20 pixels ça rend bien sur les puces de l'éditeur et de la page du poireau.