### PR TITLE
Utiliser la même équipe dans les statistiques du rapport

### DIFF
--- a/src/component/report/statistics.ts
+++ b/src/component/report/statistics.ts
@@ -3,7 +3,7 @@ import { Cell } from '@/model/cell'
 import { EffectType, EntityEffect } from '@/model/effect'
 import { Entity } from '@/model/entity'
 import { Field } from '@/model/field'
-import { Fight, FightLeek } from "@/model/fight"
+import { Fight, FightLeek, FightType } from "@/model/fight"
 import { LeekWars } from '@/model/leekwars'
 
 class StatisticsEntity extends Entity {
@@ -559,11 +559,16 @@ class FightStatistics {
 			leek.ops_per_turn_format = this.formatOps(leek.operations_per_turn)
 
 			if (leek.leek.summon) { continue }
-			if (fight.winner === 0) {
-				if (leek.leek.team === 1) { this.team1.push(leek) }
-				else { this.team2.push(leek) }
+			if (fight.type === FightType.BATTLE_ROYALE) {
+				if (fight.winner === 0) {
+					if (leek.leek.team === 1) { this.team1.push(leek) }
+					else { this.team2.push(leek) }
+				} else {
+					if (leek.leek.team === fight.winner) { this.team1.push(leek) }
+					else { this.team2.push(leek) }
+				}
 			} else {
-				if (leek.leek.team === fight.winner) { this.team1.push(leek) }
+				if (leek.leek.team === 1) { this.team1.push(leek) }
 				else { this.team2.push(leek) }
 			}
 		}


### PR DESCRIPTION
Dans les rapport de combat, l'équipe bleue est celle qui commence le combat. Or, dans les statistiques, les bleus sont ceux qui
ont gagné et les rouges les perdants. J'ai modifié ça sauf dans le cas d'une BR car c'est le seul type de combat où il y a plus de 2 équipes. (J'ai pensé à compter le nombre d'équipes pour avoir un code plus général, mais je n'ai pas trouvé de façon simple de le faire ; on pourrait itérer sur tous les poireaux et récupérer leur équipe.)
Déclaré ici : https://leekwars.com/forum/category-3/topic-10441