### PR TITLE
[editor] Adding shortcuts to fold/unfold code blocks

### DIFF
--- a/src/component/editor/ai-view.vue
+++ b/src/component/editor/ai-view.vue
@@ -250,6 +250,9 @@
 						"Alt-Right": () => null,
 						"Alt-Up": () => this.invert(true),
 						"Alt-Down": () => this.invert(false),
+						"Ctrl-U": () => this.editor.execCommand('toggleFold'),
+						"Ctrl-Y": () => this.editor.execCommand('foldAll'),
+						"Ctrl-I": () => this.editor.execCommand('unfoldAll'),
 					},
 				} as any)
 

--- a/src/component/editor/editor.vue
+++ b/src/component/editor/editor.vue
@@ -241,6 +241,9 @@
 					<li v-html="$t('shortcut.shortcut_10')"></li>
 					<li v-html="$t('shortcut.shortcut_11')"></li>
 					<li v-html="$t('shortcut.shortcut_12')"></li>
+					<li v-html="$t('shortcut.shortcut_13')"></li>
+					<li v-html="$t('shortcut.shortcut_14')"></li>
+					<li v-html="$t('shortcut.shortcut_15')"></li>
 				</ul>
 			</div>
 		</popup>

--- a/src/lang/en/shortcut.json
+++ b/src/lang/en/shortcut.json
@@ -10,5 +10,8 @@
 	"shortcut_9": "<b>Alt + left/right</b>: switch between opened files",
 	"shortcut_10": "<b>Ctrl + Space</b>: code completion",
 	"shortcut_11": "<b>Ctrl + Click</b>: go to symbol definition",
-	"shortcut_12": "<b>Ctrl + Shift + F</b>: automatic code indenting/formatting"
+	"shortcut_12": "<b>Ctrl + Shift + F</b>: automatic code indenting/formatting",
+	"shortcut_13": "<b>Ctrl + U</b> : fold/unfold the current code bloc",
+	"shortcut_14": "<b>Ctrl + Y</b> : fold all code blocs",
+	"shortcut_15": "<b>Ctrl + I</b> : unfold all code blocs"
 }

--- a/src/lang/fr/shortcut.json
+++ b/src/lang/fr/shortcut.json
@@ -10,5 +10,8 @@
 	"shortcut_9": "<b>Alt + gauche/droite</b> : basculer entre les fichiers ouverts",
 	"shortcut_10": "<b>Ctrl + Espace</b> : complétion automatique",
 	"shortcut_11": "<b>Ctrl + Clic</b> : aller à la définition du symbole",
-	"shortcut_12": "<b>Ctrl + Shift + F</b> : formatage et indentation automatique du code"
+	"shortcut_12": "<b>Ctrl + Shift + F</b> : formatage et indentation automatique du code",
+	"shortcut_13": "<b>Ctrl + U</b> : replier/déplier le bloc de code courant",
+	"shortcut_14": "<b>Ctrl + Y</b> : replier tous les blocs de code",
+	"shortcut_15": "<b>Ctrl + I</b> : déplier tous les blocs de code"
 }


### PR DESCRIPTION
Adding 3 shortcuts to the editor view, with theirs translation in the UI (FR and EN).
Ctrl+Y → Fold all code blocks.
Ctrl+U → Toggle folding current code block.
Ctrl+I → Unfold all code blocks.
Tested locally on Firefox 91.8 ESR before submitting.

Note: Deleting a fork on a not merged PR is automatically closing it.
So, reissue of https://github.com/leek-wars/leek-wars/pull/651.