### PR TITLE
Fix issue #588 for test leek characteristics

### DIFF
--- a/src/component/editor/editor-test.vue
+++ b/src/component/editor/editor-test.vue
@@ -111,7 +111,7 @@
 								<characteristic-tooltip  v-slot="{ on }" :characteristic="c" :value="currentLeek[c]" :leek="currentLeek" :test="true">
 									<img v-on="on" :src="'/image/charac/' + c + '.png'">
 								</characteristic-tooltip>
-								<span :contenteditable="!currentLeek.bot" class="stat" :class="'color-' + c" @focusout="characteristicFocusout(c, $event)" v-html="currentLeek[c]"></span>
+								<span :contenteditable="!currentLeek.bot" class="stat" :class="'color-' + c" @keyup.stop @focusout="characteristicFocusout(c, $event)" v-html="currentLeek[c]"></span>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
Using "delete" inside test leek stat inputs no longer triggers the "delete IA" popup. It will still show up if you are not in a text box though.
We might want to completely disable the shortcuts of the page under the test editor (such as ALT+arrow_left/right).