### PR TITLE
[title] Fix display with only adjective

### DIFF
--- a/src/component/title/title.vue
+++ b/src/component/title/title.vue
@@ -1,7 +1,7 @@
 <template lang="html">
 	<span class="title">
 		<span class="quote">«</span>
-		<img v-if="icon" :src="'/image/trophy/' + TROPHIES[icon - 1].code + '.svg'" :class="{notext: !noun}">
+		<img v-if="icon" :src="'/image/trophy/' + TROPHIES[icon - 1].code + '.svg'" :class="{notext: !noun && !adjective}">
 		<span v-if="$i18n.locale === 'fr'">{{ word1 }} {{ word2 }}</span>
 		<span v-else>{{ word2 }} {{ word1 }}</span>
 		<span class="quote">»</span>
@@ -48,7 +48,7 @@
 			const trophy = TROPHIES[this.adjective - 1]
 			const gender_code = i18n.locale === 'en' || this.gender === 1 || ((trophy.adj_gender & 2) !== 0) ? '' : '_f'
 			let word = this.$t('trophy.' + trophy.code + gender_code) as string
-			if (i18n.locale === 'fr') {
+			if (i18n.locale === 'fr' && this.noun) {
 				word = word.toLowerCase()
 			}
 			return word


### PR DESCRIPTION
Avec l'API on peut mettre un titre qui a un adjectif et pas de nom, et je pense qu'il n'y a pas de raison de bloquer cette possibilité.
- Affiche l'adjectif avec une majuscule s'il n'y a pas de nom
- Met une marge entre l'icône et l'adjectif s'il n'y a pas de nom

Corrige les points 1 et 2 de ce topic : https://leekwars.com/forum/category-3/topic-10723