### PR TITLE
[seed] seed + space = seed

### DIFF
--- a/src/component/editor/editor-test.vue
+++ b/src/component/editor/editor-test.vue
@@ -84,7 +84,7 @@
 							<span class="title"><v-icon>mdi-seed</v-icon> {{ $t('main.seed') }}</span>
 							<span class="desc">{{ $t('main.seed_desc') }}</span>
 						</div>
-						<input v-model="currentScenario.seed" type="number" class="seed" min="1" max="2147483647" :placeholder="$t('main.seed_placeholder')" @keyup.stop @input="updateSeed">
+						<input v-model="currentScenario.seed" type="text" class="seed" min="1" max="2147483647" :placeholder="$t('main.seed_placeholder')" @keyup.stop @input="updateSeed">
 					</div>
 				</div>
 			</v-tab-item>
@@ -1171,6 +1171,8 @@
 						this.currentScenario.seed = 2147483647
 					} else if (this.currentScenario.seed < 1) {
 						this.currentScenario.seed = 1
+					} else if (isNaN(this.currentScenario.seed)) {
+						this.currentScenario.seed = null
 					}
 				}
 				this.updateScenario(this.currentScenario, { seed: this.currentScenario.seed || 0 })

--- a/src/component/garden/garden.vue
+++ b/src/component/garden/garden.vue
@@ -121,7 +121,7 @@
 								<span class="title"><v-icon>mdi-seed</v-icon> {{ $t('main.seed') }}</span>
 								<span class="desc">{{ $t('main.seed_desc') }}</span>
 							</div>
-							<input v-model="seed" type="number" class="seed" min="1" max="2147483647" :placeholder="$t('main.seed_placeholder')" @input="updateSeed">
+							<input v-model="seed" type="text" class="seed" min="1" max="2147483647" :placeholder="$t('main.seed_placeholder')" @input="updateSeed">
 						</div>
 					</div>
 					<div v-else>
@@ -272,7 +272,7 @@
 		challengeFarmerTarget: Farmer | null = null
 		queue: number = 0
 		advanced: boolean = false
-		seed: number | null = null
+		seed: any | null = null
 		request: any = null
 
 		get farmerEnabled() { return this.garden && this.garden.farmer_enabled }
@@ -502,10 +502,13 @@
 			if (event.data === '') {
 				this.seed = null
 			} else if (this.seed) {
+				this.seed = parseInt(this.seed)
 				if (this.seed > 2147483647) {
 					this.seed = 2147483647
 				} else if (this.seed < 1) {
 					this.seed = 1
+				} else if (isNaN(this.seed)) {
+					this.seed = null
 				}
 			}
 		}


### PR DESCRIPTION
Avant, quand on entrait une seed puis qu'on mettait un espace, à cause de l'input de type "number", ça mettait "" (empty string) dans la seed. Si on met un input texte à la place, ce comportement disparaît et le parseInt se charge de supprimer le texte en trop. Par contre, si on met une lettre dans une seed vide ça afficherait "NaN" dans l'input, d'où la condition rajoutée dans updateSeed.