### PR TITLE
[statistics] Fix damage return on self AOE damage

### DIFF
--- a/src/component/report/statistics.ts
+++ b/src/component/report/statistics.ts
@@ -295,8 +295,28 @@ class FightStatistics {
 					if (state === StatisticsState.USE_ITEM) {
 						state = StatisticsState.ITEM_DAMAGE
 						lastDamageAction = action
-					} else if (state === StatisticsState.ITEM_DAMAGE && currentEntity === itemCaster) {
-						state = StatisticsState.ITEM_DAMAGE_RETURN
+					} else if (currentEntity === itemCaster) {
+						if (state === StatisticsState.ITEM_DAMAGE_RETURN) {
+							// Dégât de zone sur soi après le renvoi de dégât de la cible
+							state = StatisticsState.ITEM_DAMAGE
+						} else {
+							// Détermine si la cible a du renvoi de dégât
+							const target = entities[lastDamageAction[1]]
+							let hasDamageReturn = false
+							for (const effect_id in target.effects) {
+								const effect = target.effects[effect_id]
+								if (effect.type === EffectType.DAMAGE_RETURN) {
+									hasDamageReturn = true
+									break
+								}
+							}
+							// Si elle en a, c'est du renvoi de dégât, sinon du dégât de zone sur soi
+							if (hasDamageReturn) {
+								state = StatisticsState.ITEM_DAMAGE_RETURN
+							} else {
+								state = StatisticsState.ITEM_DAMAGE
+							}
+						}
 					}
 					const entity = entities[action[1]]
 					const damage = action[2]


### PR DESCRIPTION
Avant, si une attaque d'AOE touchait un ennemi et soi-même, les dégâts sur soi étaient comptés comme renvoi de dégâts chez l'ennemi : https://leekwars.com/forum/category-3/topic-10337

J'ai testé sur le combat 38619022.

Concernant les modifs, j'ai constaté que dans le cas ActionType.LIFE_LOST, il n'y a jamais de renvoi de dégâts, c'est géré dans le cas ActionType.DAMAGE_RETURN. Je ne suis pas 100% qu'il n'y ait pas de régressions en dehors de mon cas de test, c'est un peu compliqué les statistiques des combats ! A mon avis dans le cas LIFE_LOST on ne devrait pas à la fois toujours avoir entity.direct_dmg_in += damage et une condition sur les dégâts de poison, mais je crois qu'on n'entre pas dans LIFE_LOST sur des dégâts de poison.