### PR TITLE
Fix english translation for trophies default sorting

### DIFF
--- a/src/component/trophies/trophies.en.i18n
+++ b/src/component/trophies/trophies.en.i18n
@@ -3,7 +3,7 @@
 	"group_by_categories": "Categories",
 	"sort_by": "Sort by {0}",
 	"sort_rarity": "Rarity",
-	"sort_index": "Défaut",
+	"sort_index": "Default",
 	"sort_date": "Date",
 	"sort_points": "Points",
 	"stats": "Statistics",


### PR DESCRIPTION
In english, the word "défaut" is not translated on the trophies page. This fixes it :)