### PR TITLE
Fix white and black potion name in french

### DIFF
--- a/src/lang/fr/potion.json
+++ b/src/lang/fr/potion.json
@@ -85,7 +85,7 @@
 	"skin_greenfluo": "Potion vert fluo",
 	"skin_brown": "Potion marron",
 	"skin_blackandwhite": "Potion noire et blanche",
-	"skin_whiteandblack": "Potion blanche et noir",
+	"skin_whiteandblack": "Potion blanche et noire",
 	"skin_ghost": "Potion fantôme",
 	"skin_salmon": "Potion saumon",
 	"skin_radioactive": "Potion radioactive",


### PR DESCRIPTION
In french, the white and black potion is supposed to be "Potion blanche et noire" (the last e was missing).