### PR TITLE
fix: Translation of n_errors in report

### DIFF
--- a/src/component/report/report.en.i18n
+++ b/src/component/report/report.en.i18n
@@ -39,6 +39,6 @@
 	"winners": "Winners",
 	"errors": "Errors",
 	"errors_warnings": "Errors and warnings",
-	"n_errors": "{n} errors",
+	"n_errors": "{n} error | {n} errors",
 	"n_warnings": "{n} warnings"
 }

--- a/src/component/report/report.fr.i18n
+++ b/src/component/report/report.fr.i18n
@@ -39,6 +39,6 @@
 	"winners": "Gagnants",
 	"errors": "Erreurs",
 	"errors_warnings": "Erreurs et avertissements",
-	"n_errors": "{n} erreurs",
+	"n_errors": "{n} erreur | {n} erreurs",
 	"n_warnings": "{n} avertissements"
 }

--- a/src/component/report/report.vue
+++ b/src/component/report/report.vue
@@ -228,11 +228,7 @@
 						<v-icon v-if="report" @click="goToTurn(1)">mdi-chevron-right</v-icon>
 					</div>
 				</div>
-				<div v-if="errors.length" class="title">
-					<i18n path="n_errors">
-						<b slot="n">{{ errors.length }}</b>
-					</i18n>
-				</div>
+				<div v-if="errors.length" class="title">{{ $tc('n_errors', errors.length) }}</div>
 				<pre v-for="(e, i) in errors" :key="i" class="log error">[{{ e.entity }}] {{ e.data }}</pre>
 				<div v-if="warnings.length" class="title">
 					<i18n path="n_warnings">


### PR DESCRIPTION
When a report has only one error, it wrote "1 errors".

I did not test the change and did not change other languages.