### PR TITLE
Fix the referral link whenever user has changed its nickname

### DIFF
--- a/src/component/farmer/farmer.vue
+++ b/src/component/farmer/farmer.vue
@@ -482,7 +482,7 @@
 			{{ $t('godfather_link_description') }} :
 			<br>
 			<br>
-			<div ref="godfatherLink" class="godfather-url">leekwars.com/godfather/{{ farmer.name }}</div>
+			<div ref="godfatherLink" class="godfather-url">leekwars.com/godfather/{{ farmer.login }}</div>
 		</popup>
 
 		<popup v-if="farmer" v-model="countryDialog" :width="1000">


### PR DESCRIPTION
When some has changed its username, the referral link should still refer to his first username, not the new one. This pull request change the referral link construction to use `farmer.login` instead of `farmer.name`.

For example, my referral link should be leekwars.com/godfather/T2006 instead of leekwars.com/godfather/bwbl (which is my current username in case you want to give me the contributor badge :wink:)