### PR TITLE
[editor] Fix unwanted deletion when pressing SUPPR in other inputs

### DIFF
--- a/src/component/editor/ai-view.vue
+++ b/src/component/editor/ai-view.vue
@@ -16,8 +16,8 @@
 		</div>
 		<div v-show="searchEnabled" class="search-panel">
 			<div class="inputs">
-				<input ref="searchInput" v-model="searchQuery" type="text" autocomplete="off" :placeholder="$t('main.search')" @keyup.enter="$event.shiftKey ? searchPrevious() : searchNext()">
-				<input ref="replaceInput" v-model="replaceQuery" type="text" autocomplete="off" :placeholder="$t('main.replace')" @keyup.enter="replaceOne">
+				<input ref="searchInput" v-model="searchQuery" type="text" autocomplete="off" :placeholder="$t('main.search')" @keyup.stop @keyup.enter="$event.shiftKey ? searchPrevious() : searchNext()">
+				<input ref="replaceInput" v-model="replaceQuery" type="text" autocomplete="off" :placeholder="$t('main.replace')" @keyup.stop @keyup.enter="replaceOne">
 			</div>
 			<div class="buttons">
 				<div>

--- a/src/component/editor/editor-finder.vue
+++ b/src/component/editor/editor-finder.vue
@@ -1,6 +1,6 @@
 <template lang="html">
 	<div v-if="value" class="finder" @click.stop>
-		<input v-if="search" ref="input" v-model="query" class="input" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" @change="change" @keydown="keydown">
+		<input v-if="search" ref="input" v-model="query" class="input" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" @keyup.stop @change="change" @keydown="keydown">
 		<div ref="list" class="results">
 			<div v-for="(result, r) of results" :key="result.ai.id" class="result active" :class="{selected: selected === r}" @click="go(result.ai)">
 				<v-icon v-if="result.ai.errors" class="icon error">mdi-close-circle</v-icon>


### PR DESCRIPTION
I would sometimes delete files that I didn't mean to while using the search bar and pressing the "SUPPR/DELETE" key on my keyboard. Adding these keyup.stop seem to do the trick, but I'm not 100% sure that it is the way to go. (I could also check in the keyup function that we're not currently typing in a input tag).