### PR TITLE
[feature] GitHub URL regexp username

### DIFF
--- a/src/component/farmer/farmer.vue
+++ b/src/component/farmer/farmer.vue
@@ -880,8 +880,14 @@
 
 		changeGithub() {
 			if (!this.farmer) { return }
-			this.farmer.github = this.newGitHub
-			LeekWars.post('farmer/set-github', {github: this.newGitHub})
+			/* If the user enter his GitHub's URL like `github.com/username` or `https://github.com/username`,
+			it will only keep `username` */
+			let newGitHub = this.newGitHub.replace(
+				/^(?:https?:\/\/)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\/\b/,
+				''
+			)
+			this.farmer.github = newGitHub
+			LeekWars.post('farmer/set-github', {github: newGitHub})
 			this.githubDialog = false
 		}
 


### PR DESCRIPTION
When changing GitHub URL :

- `github.com/username` → `username`
- `https://github.com/username/` → `username/`
- `www.github.com/username` → `username`
- `username` → `username`

It avoids having ugly GitHub urls like : 
![image](https://github.com/leek-wars/leek-wars/assets/30987143/3597a98d-f6cb-4caa-8a43-794fc980a1a1)

So the user can either copy and paste his GitHub profile link (or a repository), or he can just enter his username.