### PR TITLE
[editor] Fix missing lines when exporting code

### DIFF
--- a/src/component/editor/editor-explorer.vue
+++ b/src/component/editor/editor-explorer.vue
@@ -390,7 +390,7 @@
 		downloadIncludes() {
 			if (!this.ai) { return }
 
-			const regex = /.*include\s*\(\s*["'](.*?)["']\s*\)\s*;?.*/gm
+			const regex = /^[ \t\/*]*include\s*\(\s*["'](.*?)["']\s*\)[ \t]*;?.*$/gm
 			const regexComment1 = /^\s*\/\/.*$/
 			const regexComment2 = /^\s*\/\*.*\*\//
 


### PR DESCRIPTION
Some people complained ([here](https://leekwars.com/forum/category-3/topic-11040)) about having missing lines in their files. I suspected it had to do with the PR here https://github.com/leek-wars/leek-wars/commit/87c1f59d492cc634f5b5adad29171ebfb913d259 where the regexp was changed.

And indeed it was. It looks like the current regexp matches too many lines because of the "\s" when we don't use the ";" as a separator, the regexp matches the line below, and we delete all of the regexp match (even the extra line) to replace it with the included content.

Bonus point, it could also break functions which had "include" in the name. (example given below)

How to reproduce the bug : 

```
// File : main.leek
include('test.leek');
include('duplicated.leek')
// This line will disappear upon downloading...
// ...But this one is fine
```
```
// File : test.leek
include('duplicated.leek')
// This one will also disappear...
// ...but ok in test
```
```
// File : duplicated.leek
say('Hello');
function array_include(string value){}
array_include('haha je casse tout');
// ... où est passé mon appel de fonction array_include ??
```

Here are test cases that I used on the website https://regex101.com/
```

include ( 'test')

Ligne avant
include("pouet")

a

include('pouet')

;

is_aoe_include('test');

include('test');
include('test');
include('test');
azeaze

include(
'test'
);


// include('code'); // le code principal

include('oui oui')

// include('oui');

/* include('oui'); */
```