### PR TITLE
fix: Tri chapeaux

### DIFF
--- a/src/component/inventory/inventory.vue
+++ b/src/component/inventory/inventory.vue
@@ -62,7 +62,7 @@
 		</template>
 		<div slot="content" ref="inventory" class="inventory-content">
 			<div class="inventory">
-				<div v-for="item in sorted_inventory" :key="item.template" class="cell active" :class="'rarity-border-' + LeekWars.items[item.template].rarity">
+				<div v-for="item in sorted_inventory" :key="item.id" class="cell active" :class="'rarity-border-' + LeekWars.items[item.template].rarity">
 					<rich-tooltip-item v-slot="{ on }" :bottom="true" :item="LeekWars.items[item.template]" :quantity="item.quantity" :inventory="true" @retrieve="retrieve">
 						<div v-on="on" class="item"  :quantity="item.quantity | number" :type="LeekWars.items[item.template].type">
 							<img v-if="item.type === ItemType.RESOURCE" class="image" :src="'/image/resource/' + LeekWars.items[item.template].name + '.png'">


### PR DESCRIPTION
Avec template en clé il y avait des clés en double. Des erreurs l'indiquait dans la console, et ça causait un plantage de toute Vue.js. Cette modification corrige le plantage quand on passait du filtre Tout à Chapeaux : https://leekwars.com/forum/category-3/topic-10445
J'avais déjà corrigé ça dans le commit 422a0a6e2 mais Pilow l'a re-cassé !