### PR TITLE
Made feminine trophy names default to the masculine variation if absent

### DIFF
--- a/src/component/title/title-picker.vue
+++ b/src/component/title/title-picker.vue
@@ -99,7 +99,9 @@
 			}).map((w: any) => {
 				const trophy = TROPHIES[w.id - 1]
 				const gender_code = this.gender === 2 && (trophy.noun_translation & 2) && ((trophy.noun_gender & 2) === 0) ? '_f' : ''
-				return {code: w.code, id: w.id, t: this.$t('trophy.' + w.code + gender_code) as string, rarity: w.rarity}
+				let t = this.$t('trophy.' +	w.code + gender_code);
+				if (t == 'trophy.' + w.code + gender_code) { t = this.$t('trophy.' + w.code) }
+				return {code: w.code, id: w.id, t: t as string, rarity: w.rarity}
 			}).sort((a: any, b: any) => a.t.localeCompare(b.t)))
 		}
 		get adjectives() {
@@ -108,7 +110,9 @@
 			}).map((w: any) => {
 				const trophy = TROPHIES[w.id - 1]
 				const gender_code = this.gender === 2 && (trophy.adj_translation & 2) && ((trophy.adj_gender & 2) === 0) ? '_f' : ''
-				return {code: w.code, id: w.id, t: this.$t('trophy.' + w.code + gender_code) as string, rarity: w.rarity}
+				let t = this.$t('trophy.' +	w.code + gender_code);
+				if (t == 'trophy.' + w.code + gender_code) { t = this.$t('trophy.' + w.code) }
+				return {code: w.code, id: w.id, t: t as string, rarity: w.rarity}
 			}).sort((a: any, b: any) => a.t.localeCompare(b.t)))
 		}
 

--- a/src/component/title/title.vue
+++ b/src/component/title/title.vue
@@ -37,6 +37,7 @@
 			const trophy = TROPHIES[this.noun - 1]
 			const gender_code = this.gender === 1 || ((trophy.noun_gender & 2) !== 0) ? '' : '_f'
 			let word = this.$t('trophy.' + trophy.code + gender_code) as string
+			if (word == 'trophy.' + trophy.code + gender_code) { word = this.$t('trophy.' + trophy.code) as string }
 			if (i18n.locale === 'en' && this.adjective && word !== word.toUpperCase()) {
 				word = word.toLowerCase()
 			}
@@ -48,6 +49,7 @@
 			const trophy = TROPHIES[this.adjective - 1]
 			const gender_code = this.gender === 1 || ((trophy.adj_gender & 2) !== 0) ? '' : '_f'
 			let word = this.$t('trophy.' + trophy.code + gender_code) as string
+			if (word == 'trophy.' + trophy.code + gender_code) { word = this.$t('trophy.' + trophy.code) as string }
 			if (i18n.locale === 'fr' && this.noun && word !== word.toUpperCase()) {
 				word = word.toLowerCase()
 			}

--- a/src/lang/fr/trophy.json
+++ b/src/lang/fr/trophy.json
@@ -386,6 +386,7 @@
 	"gladiator_f": "Gladiatrice",
 	"gust": "Bourrasque",
 	"hedgehog": "Hérisson",
+	"hedgehog_f": "Hérissonne",
 	"he_is_beautiful": "Il est tout beau",
 	"herbicide": "Herbicide",
 	"herborist": "Herboriste",


### PR DESCRIPTION
I added one trophy name that was absent (trophy.hedgehog_f) and made trophies default to the masculine version of the trophy name. Since a lot of trophies have a similar name, it should allow some leniency when it comes to missing translations