### PR TITLE
feat: éviter le spoil des tournois et BR

### DIFF
--- a/src/model/socket.ts
+++ b/src/model/socket.ts
@@ -179,9 +179,19 @@ class Socket {
 				case SocketMessage.NOTIFICATION_RECEIVE : {
 
 					const message = { id: data[0], type: data[1], date: LeekWars.time, parameters: data[2], new: true }
+					
+					const spoilableTypes = [NotificationType.BATTLE_ROYALE_STARTED, NotificationType.FIGHT_REPORT, NotificationType.COMPOSITION_FIGHT_REPORT];
+					const fightIdIndex = {
+						NotificationType.BATTLE_ROYALE_STARTED: 0,
+						NotificationType.FIGHT_REPORT: 1,
+						NotificationType.COMPOSITION_FIGHT_REPORT: 1,
+						NotificationType.TOURNAMENT_WINNER: 2,
+					};
 					// Envoie de la notif sur la page du combat pour la mettre en file d'attente
 					if (message.type === NotificationType.TROPHY_UNLOCKED && router.currentRoute.path.startsWith('/fight/' + message.parameters[1])) {
 						vueMain.$emit('trophy', message)
+					} else if (spoilableTypes.indexOf(message.type) !== -1 && router.currentRoute.path.startsWith('/fight/' + message.parameters[fightIdIndex[message.type])) {
+						vueMain.$emit('fight_notification', message)
 					} else {
 						if (message.type === NotificationType.UP_LEVEL) {
 							const leek = parseInt(message.parameters[0], 10)


### PR DESCRIPTION
**:warning: IL Y A DU CODE A CHANGER SERVER SIDE :** 
Il faut que la notificaiton NotificationType.TOURNAMENT_WINNER retourne l'ID du combat en paramètre d'index [2] !
(car aujourd'hui on a que l'id du tournoi, mais on ne peut pas le déduire depuis la page du trophée je crois).

:warning: je n'ai pas testé le code, j'ai écrit tout depuis github sans rien installer en local :)