### PR TITLE
Desktop notifications for the chat

### DIFF
--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -1,6 +1,7 @@
 import { Farmer } from '@/model/farmer'
 import { i18n } from '@/model/i18n'
 import Vue from 'vue'
+import { LeekWars } from './leekwars'
 
 enum ChatType { GLOBAL, TEAM, PM, GROUP }
 
@@ -76,6 +77,29 @@ class Chat {
 		}
 		Vue.set(this, 'last_message', message.content.replace(/<br>/g, '\n'))
 		day_messages.push(message)
+
+		// Desktop notification
+		if (!this.loading && 'Notification' in window && document.visibilityState === 'hidden') {
+			if (Notification.permission === 'granted') {
+				this.notify(message)
+			} else {
+				Notification.requestPermission().then((permission) => {
+					if (permission === 'granted') {
+						this.notify(message)
+					}
+				})
+			}
+		}
+	}
+
+	notify(message: ChatMessage) {
+		new Notification(
+			message.farmer.name + ' (' + this.name + ')',
+			{
+				body: message.content,
+				icon: LeekWars.getAvatar(message.farmer.id, message.farmer.avatar_changed)
+			}
+		)
 	}
 
 	unshift(message: ChatMessage) {


### PR DESCRIPTION
Cette PR ajoute des [notifications de bureau](https://developer.mozilla.org/fr/docs/Web/API/Notification) pour le chat. L'avantage par rapport aux notifications intégrées à la page est qu'on les voit même quand le navigateur n'est pas visible. Ça permet de discuter ou de réagir rapidement tout en faisant autre chose.

Lors du premier message reçu, la permission est demandée au navigateur. Sous Firefox, il faut cliquer sur un bouton pour faire apparaître la demande de permission. Tant qu'on n'a pas autorisé, les notifications n'apparaissent pas. C'est pour ça qu'il n'est pas forcément nécessaire d'ajouter un paramètre dans l'interface. À moins que ça pose problème si on a plusieurs onglets avec plusieurs comptes ouverts en même temps.

La notification n'est pas affichée quand l'onglet est visible.

Il manque encore de ne pas afficher de notification pour les messages qu'on a envoyés soi-même. Mais je ne sais pas comment accéder à l'id de l'éleveur à cet endroit.

On pourrait aussi définir l'action quand la notification est cliquée : ça pourrait scroller le chat et rendre visible le salon ou la conversation concerné.