### PR TITLE
Fix des mentions contenant des accents qui ne fonctionnaient pas

### DIFF
--- a/src/component/chat/chat.vue
+++ b/src/component/chat/chat.vue
@@ -439,7 +439,7 @@
 			content = LeekWars.linkify(content)
 			content = formatEmojis(content)
 			content = Commands.execute(content, message.farmer.name)
-			content = content.replace(/@(\w+)/g, (a, b) => {
+			content = content.replace(/@[0-9A-zÀ-ú\w]+/g, (a, b) => {
 				const farmer = store.state.farmer_by_name[b]
 				if (farmer) {
 					return "<span class='pseudo'>" + b + "</span>"


### PR DESCRIPTION
Il s'agit ici d'ajouter un support des caractères accentués dans les mentions, actuellement les mentions ne fonctionnent que si elles contiennent uniquement des caractères alphanumériques. Pas testé mais devrait fonctionner en principe.