### PR TITLE
Fix editor focus loss after mouse drag-select and improve UI interactivity

### DIFF
--- a/src/component/editor/ai-view-monaco.vue
+++ b/src/component/editor/ai-view-monaco.vue
@@ -108,13 +108,18 @@ export default class AIViewMonaco extends Vue {
 			// console.log('scroll', this.ai.id, e.scrollTop, e.scrollHeight, e.scrollWidth)
 			localStorage.setItem('editor/scroll/' + this.ai.id, '' + e.scrollTop)
 		})
-		// this.editor.onDidFocusEditorWidget((e) => {
-		// 	// Verify the correct model is active when focusing
-		// 	if (this.ai && this.ai.model && this.editor.getModel() !== this.ai.model) {
-		// 		this.editor.setModel(this.ai.model)
-		// 	}
-		// 	this.$emit('focus')
-		// })
+		// Restore focus after mouse drag-select to prevent first keystroke
+		// from being lost (#817)
+		this.editor.onMouseUp(() => {
+			requestAnimationFrame(() => {
+				if (!this.editor.hasTextFocus()) {
+					this.editor.focus()
+				}
+			})
+		})
+		this.editor.onDidFocusEditorWidget(() => {
+			this.$emit('focus')
+		})
 		this.editor.onKeyDown((e) => {
 			if (e.code === 'Enter') {
 				if (this.console) {
@@ -424,6 +429,7 @@ export default class AIViewMonaco extends Vue {
 	margin-left: -250px;
 	text-align: center;
 	z-index: 1000;
+	pointer-events: none;
 }
 .compiling {
 	padding: 5px 10px;
@@ -431,6 +437,7 @@ export default class AIViewMonaco extends Vue {
 	background: var(--pure-white);
 	margin: 4px;
 	display: inline-block;
+	pointer-events: auto;
 }
 .compiling .loader {
 	display: inline-block;
@@ -447,6 +454,7 @@ export default class AIViewMonaco extends Vue {
 	padding: 5px 10px;
 	border-radius: 2px;
 	margin: 4px;
+	pointer-events: auto;
 }
 .results {
 	cursor: pointer;


### PR DESCRIPTION
## Summary
This PR addresses an issue where the first keystroke was lost after performing a mouse drag-select operation in the Monaco editor, and improves pointer event handling for UI overlays.

## Key Changes
- **Focus restoration after mouse drag-select**: Added an `onMouseUp` handler that restores editor focus after mouse operations to prevent keystroke loss (#817)
  - Uses `requestAnimationFrame` to defer focus restoration until after the current frame
  - Only refocuses if the editor doesn't already have text focus
  
- **Re-enabled focus event emission**: Uncommented and simplified the `onDidFocusEditorWidget` handler to emit a 'focus' event when the editor gains focus

- **Improved pointer event handling**: Added `pointer-events` CSS properties to prevent unintended event capture
  - Set `pointer-events: none` on the overlay container to allow clicks to pass through
  - Set `pointer-events: auto` on interactive elements (`.compiling` and `.results`) to restore click handling

## Implementation Details
The focus restoration uses `requestAnimationFrame` to ensure the focus operation happens after the browser has finished processing the mouse event, preventing race conditions with the editor's internal focus management.

https://claude.ai/code/session_012vtDLdZEFoTohWGkUousLG