### PR TITLE
Add farmer talent history chart to farmer page

### DIFF
--- a/src/model/farmer.ts
+++ b/src/model/farmer.ts
@@ -43,6 +43,7 @@ class Farmer {
 	public moderator!: boolean
 	public admin!: boolean
 	public talent!: number
+	public talent_history!: number[]
 	public team!: Team | null
 	public total_level!: number
 	public ais!: AI[]


### PR DESCRIPTION
Same mechanism as leek solo talent history: displays a 7-day Line chart
of the farmer's talent evolution in the stats panel, using the
talent_history field from the API.

https://claude.ai/code/session_01Cheb9f13EYMNrTiCB9BjBU