### PR TITLE
feat(market): add keyboard arrow navigation between items (#453)

### DIFF
--- a/src/component/changelog/changelog.en.yaml
+++ b/src/component/changelog/changelog.en.yaml
@@ -6,6 +6,7 @@
     - "Tournaments: All registered players now participate, evenly distributed across multiple tournaments of 16 to 32 players instead of excluding extra players."
     - "Editor: improved Ctrl+click to go to symbol definition (more reliable navigation and correct scrolling)."
     - "LeekScript: semicolon after while() in do-while loops is now optional."
+    - "Market: keyboard navigation with up/down/left/right arrow keys between items."
   fixed:
     - "LeekScript: fixed a crash when compiling classes in certain include scenarios, and improved case handling for class and include keywords."
     - Fixed a bug preventing team fights when the turret AI was missing.

--- a/src/component/changelog/changelog.fr.yaml
+++ b/src/component/changelog/changelog.fr.yaml
@@ -9,6 +9,7 @@
     - "Tournois : Tous les joueurs inscrits participent maintenant, répartis équitablement entre plusieurs tournois de 16 à 32 joueurs au lieu d'exclure les joueurs en trop."
     - "Éditeur : amélioration du Ctrl+clic pour aller à la définition d'un symbole (navigation plus fiable et scroll correct)."
     - "LeekScript : le point-virgule après while() dans les boucles do-while est maintenant optionnel."
+    - "Marché : navigation au clavier avec les flèches haut/bas/gauche/droite entre les items."
   fixed:
     - "LeekScript : correction d'un crash lors de la compilation de classes dans certains cas d'include, et meilleure gestion de la casse sur les mots-clés class et include."
     - Correction d'un bug empêchant les combats d'équipe quand l'IA de la tourelle était inexistante.


### PR DESCRIPTION
Allow navigating between market items using left/right arrow keys.
The navigation follows the display order (fight packs → weapons → chips →
potions → hats → pomps) and wraps around. Disabled when a dialog is open.

https://claude.ai/code/session_01G411CqywSoMNwjWXdi4oxq