### PR TITLE
Gérer l'erreur "Unable to preload CSS" après un déploiement

### DIFF
--- a/src/model/vue.ts
+++ b/src/model/vue.ts
@@ -87,12 +87,18 @@ function displayWarningMessage() {
 }
 
 // Handle Vite CSS/JS preload errors after deployment (stale hashed assets)
-window.addEventListener('vite:preloadError', (e) => {
-	const reloadKey = 'vite-preload-reload'
-	if (!sessionStorage.getItem(reloadKey)) {
-		sessionStorage.setItem(reloadKey, '1')
+// The guard flag prevents infinite reload loops if the error persists after reload.
+// It is cleared on successful page load so that future deploys can trigger a reload again.
+const PRELOAD_RELOAD_KEY = 'vite-preload-reload'
+window.addEventListener('vite:preloadError', () => {
+	if (!sessionStorage.getItem(PRELOAD_RELOAD_KEY)) {
+		sessionStorage.setItem(PRELOAD_RELOAD_KEY, '1')
 		window.location.reload()
 	}
+})
+// Clear the guard once the page has loaded successfully (assets are fresh)
+window.addEventListener('load', () => {
+	sessionStorage.removeItem(PRELOAD_RELOAD_KEY)
 })
 
 let lastErrorSent = 0

--- a/src/model/vue.ts
+++ b/src/model/vue.ts
@@ -86,6 +86,15 @@ function displayWarningMessage() {
 	console.log("")
 }
 
+// Handle Vite CSS/JS preload errors after deployment (stale hashed assets)
+window.addEventListener('vite:preloadError', (e) => {
+	const reloadKey = 'vite-preload-reload'
+	if (!sessionStorage.getItem(reloadKey)) {
+		sessionStorage.setItem(reloadKey, '1')
+		window.location.reload()
+	}
+})
+
 let lastErrorSent = 0
 
 let secondInterval: any = null, minuteInterval: any = null
@@ -255,10 +264,11 @@ const app = createApp({
 
 		if (LeekWars.DEV) return
 
-		// Ignore chunk loading errors (handled by router.onError with page reload)
+		// Ignore chunk loading errors (handled by router.onError / vite:preloadError with page reload)
 		if (err.message?.includes('Failed to fetch dynamically imported module') ||
 			err.message?.includes('Loading chunk') ||
-			err.message?.includes('Loading CSS chunk')) {
+			err.message?.includes('Loading CSS chunk') ||
+			err.message?.includes('Unable to preload CSS')) {
 			return
 		}
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -279,6 +279,7 @@ router.onError((error, to) => {
 		error.message.includes('Failed to fetch dynamically imported module') ||
 		error.message.includes('Loading chunk') ||
 		error.message.includes('Loading CSS chunk') ||
+		error.message.includes('Unable to preload CSS') ||
 		error.name === 'ChunkLoadError'
 	) {
 		// Prevent infinite reload loop


### PR DESCRIPTION
Après un déploiement, les fichiers CSS hashés (ex: footer-jC4mFHTo.css)
n'existent plus sur le serveur. Les utilisateurs avec l'ancien JS en cache
obtiennent l'erreur "Unable to preload CSS" de Vite, qui n'était pas gérée.

- Ajouter un handler vite:preloadError qui recharge la page automatiquement
- Ajouter "Unable to preload CSS" aux filtres d'erreurs dans router.onError
  et errorCaptured pour éviter les faux rapports d'erreurs

https://claude.ai/code/session_01E522KYWz2NVVjeKb1DDExV