### PR TITLE
feat: éviter le spoil des tournois et BR

### DIFF
--- a/src/component/fight/fight.vue
+++ b/src/component/fight/fight.vue
@@ -249,7 +249,7 @@ import { emitter } from '@/model/vue'
 			for (const message of this.trophyQueue) {
 				store.commit('notification', message)
 			}
-			for (const message of this.notificationQueue) {
+			for (const message of this.fightNotificationQueue) {
 				store.commit('notification', message)
 			}
 		}

--- a/src/component/fight/fight.vue
+++ b/src/component/fight/fight.vue
@@ -156,7 +156,7 @@ import { emitter } from '@/model/vue'
 		reportDialog: boolean = false
 		reasons = [Warning.RUDE_SAY, Warning.INCORRECT_LEEK_NAME, Warning.INCORRECT_FARMER_NAME, Warning.INCORRECT_AVATAR]
 		trophyQueue: any[] = []
-		notificationQueue: any[] = []
+		fightNotificationQueue: any[] = []
 
 		get reportLeeks() {
 			if (!this.fight) { return [] }

--- a/src/component/fight/fight.vue
+++ b/src/component/fight/fight.vue
@@ -16,7 +16,7 @@
 		<panel class="first">
 			<template #content>
 				<div class="fight">
-					<player v-if="fight_id" :key="fight_id" :fight-id="fight_id" :required-width="playerWidth" :required-height="playerHeight" :horizontal="playerHorizontal" :start-turn="startTurn" :start-action="startAction" @unlock-trophy="unlockTrophy" @display-fight-notification="displayFightNotification" @fight="fightLoaded" @resize="resize" />
+					<player v-if="fight_id" :key="fight_id" :fight-id="fight_id" :required-width="playerWidth" :required-height="playerHeight" :horizontal="playerHorizontal" :start-turn="startTurn" :start-action="startAction" @unlock-trophy="unlockTrophy" @fight="fightLoaded" @resize="resize" />
 				</div>
 			</template>
 		</panel>

--- a/src/component/fight/fight.vue
+++ b/src/component/fight/fight.vue
@@ -138,7 +138,7 @@
 	import ReportDialog from '@/component/moderation/report-dialog.vue'
 	import { BOSSES } from '@/model/boss'
 	import { defineAsyncComponent, nextTick } from 'vue'
-import { emitter } from '@/model/vue'
+	import { emitter } from '@/model/vue'
 
 	@Options({ name: "fight", components: { 'player': Player, Comments, RichTooltipFarmer, RichTooltipTeam, 'report-dialog': ReportDialog }, i18n: {}, mixins: [...mixins] })
 	export default class FightPage extends Vue {
@@ -281,7 +281,7 @@ import { emitter } from '@/model/vue'
 
 		// Réception des notifications pour les mettre en attente
 		onFightNotification(message: any) {
-			this.notificationQueue.push(message)
+			this.fightNotificationQueue.push(message)
 		}
 
 		// Le player a joué un trophée, on peut l'afficher

--- a/src/component/fight/fight.vue
+++ b/src/component/fight/fight.vue
@@ -183,7 +183,7 @@ import { emitter } from '@/model/vue'
 			setTimeout(() => this.resize(), 50)
 
 			emitter.on('trophy', this.onTrophy)
-			emitter.on('fight_notification', this.displayFightNotification)
+			emitter.on('fight_notification', this.onFightNotification)
 		}
 
 		@Watch('$route.params.id', {immediate: true})
@@ -243,7 +243,7 @@ import { emitter } from '@/model/vue'
 			LeekWars.lightBar = false
 			emitter.off('resize', this.resize)
 			emitter.off('trophy', this.onTrophy)
-			emitter.off('fight_notification', this.displayFightNotification)
+			emitter.off('fight_notification', this.onFightNotification)
 
 			// Notifications de trophées restants
 			for (const message of this.trophyQueue) {
@@ -293,15 +293,6 @@ import { emitter } from '@/model/vue'
 					this.trophyQueue.splice(m, 1)
 					m--
 				}
-			}
-		}
-
-		displayFightNotification() {
-			for (let m = 0; m < this.notificationQueue.length; ++m) {
-				const message = this.notificationQueue[m]
-				store.commit('notification', message)
-				this.notificationQueue.splice(m, 1)
-				m--
 			}
 		}
 

--- a/src/component/fight/fight.vue
+++ b/src/component/fight/fight.vue
@@ -280,8 +280,8 @@ import { emitter } from '@/model/vue'
 		}
 
 		// Réception des notifications pour les mettre en attente
-		onFightNotification(notification: any) {
-			this.notificationQueue.push(notification)
+		onFightNotification(message: any) {
+			this.notificationQueue.push(message)
 		}
 
 		// Le player a joué un trophée, on peut l'afficher

--- a/src/model/socket.ts
+++ b/src/model/socket.ts
@@ -191,11 +191,11 @@ class Socket {
 					const fightIdIndex: Record<number, number> = {
 						[NotificationType.BATTLE_ROYALE_STARTED]: 0,
 						[NotificationType.FIGHT_REPORT]: 1,
+						[NotificationType.FARMER_FIGHT_REPORT]: 1,
 						[NotificationType.COMPOSITION_FIGHT_REPORT]: 1,
-						[NotificationType.TOURNAMENT_WINNER]: 2,
 						[NotificationType.CHALLENGE]: 1,
 						[NotificationType.FARMER_CHALLENGE]: 1,
-						[NotificationType.FARMER_FIGHT_REPORT]: 1,
+						[NotificationType.TOURNAMENT_WINNER]: 2,
 						[NotificationType.FARMER_TOURNAMENT_WIN]: 2,
 						[NotificationType.TEAM_TOURNAMENT_WIN]: 2
 					};

--- a/src/model/socket.ts
+++ b/src/model/socket.ts
@@ -181,9 +181,19 @@ class Socket {
 				case SocketMessage.NOTIFICATION_RECEIVE : {
 
 					const message = { id: data[0], type: data[1], date: LeekWars.time, parameters: data[2], new: true }
+					
+					const spoilableTypes = [NotificationType.BATTLE_ROYALE_STARTED, NotificationType.FIGHT_REPORT, NotificationType.COMPOSITION_FIGHT_REPORT];
+					const fightIdIndex: Record<number, number> = {
+						[NotificationType.BATTLE_ROYALE_STARTED]: 0,
+						[NotificationType.FIGHT_REPORT]: 1,
+						[NotificationType.COMPOSITION_FIGHT_REPORT]: 1,
+						[NotificationType.TOURNAMENT_WINNER]: 2,
+					};
 					// Envoie de la notif sur la page du combat pour la mettre en file d'attente
 					if (message.type === NotificationType.TROPHY_UNLOCKED && router.currentRoute.value.path.startsWith('/fight/' + message.parameters[1])) {
 						emitter.emit('trophy', message)
+					} else if (spoilableTypes.indexOf(message.type) !== -1 && router.currentRoute.value.path.startsWith('/fight/' + message.parameters[fightIdIndex[message.type]])) {
+						emitter.emit('fight_notification', message)
 					} else {
 						if (message.type === NotificationType.UP_LEVEL) {
 							const leek = parseInt(message.parameters[0], 10)

--- a/src/model/socket.ts
+++ b/src/model/socket.ts
@@ -182,27 +182,19 @@ class Socket {
 
 					const message = { id: data[0], type: data[1], date: LeekWars.time, parameters: data[2], new: true }
 					
-					const spoilableTypes = [
-						NotificationType.BATTLE_ROYALE_STARTED,
-						NotificationType.FIGHT_REPORT, NotificationType.FARMER_FIGHT_REPORT, NotificationType.COMPOSITION_FIGHT_REPORT,
-						NotificationType.CHALLENGE, NotificationType.FARMER_CHALLENGE,
-						NotificationType.TOURNAMENT_WINNER, NotificationType.FARMER_TOURNAMENT_WIN, NotificationType.TEAM_TOURNAMENT_WIN
-					];
-					const fightIdIndex: Record<number, number> = {
-						[NotificationType.BATTLE_ROYALE_STARTED]: 0,
-						[NotificationType.FIGHT_REPORT]: 1,
-						[NotificationType.FARMER_FIGHT_REPORT]: 1,
-						[NotificationType.COMPOSITION_FIGHT_REPORT]: 1,
-						[NotificationType.CHALLENGE]: 1,
-						[NotificationType.FARMER_CHALLENGE]: 1,
-						[NotificationType.TOURNAMENT_WINNER]: 2,
-						[NotificationType.FARMER_TOURNAMENT_WIN]: 2,
-						[NotificationType.TEAM_TOURNAMENT_WIN]: 2
-					};
+					const spoilableTypes: number[] = [NotificationType.BATTLE_ROYALE_STARTED, NotificationType.FIGHT_REPORT, NotificationType.FARMER_FIGHT_REPORT, NotificationType.COMPOSITION_FIGHT_REPORT, NotificationType.CHALLENGE, NotificationType.FARMER_CHALLENGE, NotificationType.TOURNAMENT_WINNER, NotificationType.FARMER_TOURNAMENT_WIN, NotificationType.TEAM_TOURNAMENT_WIN]
+
 					// Envoie de la notif sur la page du combat pour la mettre en file d'attente
 					if (message.type === NotificationType.TROPHY_UNLOCKED && router.currentRoute.value.path.startsWith('/fight/' + message.parameters[1])) {
 						emitter.emit('trophy', message)
-					} else if (spoilableTypes.indexOf(message.type) !== -1 && router.currentRoute.value.path.startsWith('/fight/' + message.parameters[fightIdIndex[message.type]])) {
+					} else if (
+						spoilableTypes.indexOf(message.type) !== -1
+						&& (
+							((message.type === NotificationType.BATTLE_ROYALE_STARTED || message.type === NotificationType.FARMER_CHALLENGE) && router.currentRoute.value.path.startsWith('/fight/' + message.parameters[0]))
+							|| ((message.type === NotificationType.FIGHT_REPORT || message.type === NotificationType.FARMER_FIGHT_REPORT || message.type === NotificationType.COMPOSITION_FIGHT_REPORT || message.type === NotificationType.CHALLENGE) && router.currentRoute.value.path.startsWith('/fight/' + message.parameters[1]))
+							|| ((message.type === NotificationType.TOURNAMENT_WINNER || message.type === NotificationType.FARMER_TOURNAMENT_WIN || message.type === NotificationType.TEAM_TOURNAMENT_WIN) && router.currentRoute.value.path.startsWith('/fight/' + message.parameters[2]))
+						)
+					) {
 						emitter.emit('fight_notification', message)
 					} else {
 						if (message.type === NotificationType.UP_LEVEL) {

--- a/src/model/socket.ts
+++ b/src/model/socket.ts
@@ -182,12 +182,22 @@ class Socket {
 
 					const message = { id: data[0], type: data[1], date: LeekWars.time, parameters: data[2], new: true }
 					
-					const spoilableTypes = [NotificationType.BATTLE_ROYALE_STARTED, NotificationType.FIGHT_REPORT, NotificationType.COMPOSITION_FIGHT_REPORT];
+					const spoilableTypes = [
+						NotificationType.BATTLE_ROYALE_STARTED,
+						NotificationType.FIGHT_REPORT, NotificationType.FARMER_FIGHT_REPORT, NotificationType.COMPOSITION_FIGHT_REPORT,
+						NotificationType.CHALLENGE, NotificationType.FARMER_CHALLENGE,
+						NotificationType.TOURNAMENT_WINNER, NotificationType.FARMER_TOURNAMENT_WIN, NotificationType.TEAM_TOURNAMENT_WIN
+					];
 					const fightIdIndex: Record<number, number> = {
 						[NotificationType.BATTLE_ROYALE_STARTED]: 0,
 						[NotificationType.FIGHT_REPORT]: 1,
 						[NotificationType.COMPOSITION_FIGHT_REPORT]: 1,
 						[NotificationType.TOURNAMENT_WINNER]: 2,
+						[NotificationType.CHALLENGE]: 1,
+						[NotificationType.FARMER_CHALLENGE]: 1,
+						[NotificationType.FARMER_FIGHT_REPORT]: 1,
+						[NotificationType.FARMER_TOURNAMENT_WIN]: 2,
+						[NotificationType.TEAM_TOURNAMENT_WIN]: 2
 					};
 					// Envoie de la notif sur la page du combat pour la mettre en file d'attente
 					if (message.type === NotificationType.TROPHY_UNLOCKED && router.currentRoute.value.path.startsWith('/fight/' + message.parameters[1])) {

--- a/src/model/vue.ts
+++ b/src/model/vue.ts
@@ -130,6 +130,7 @@ type Events = {
 	'editor-drag': any
 	'tournament-update': any
 	trophy: any
+	fight_notification: any
 	wsmessage: { type: number, data: any, id: number | null },
 	mousemove: any,
 	mouseup: any,


### PR DESCRIPTION
## Summary
- Met en file d'attente les notifications de combat (résultats de tournois, BR, challenges, fight reports) quand le joueur est sur la page du combat correspondant, pour éviter le spoil
- Les notifications sont affichées une fois le combat terminé ou quand le joueur quitte la page

Basé sur la PR #747 de @whiteslash, rebasé sur master avec corrections :
- Migration Vue 2 → Vue 3 (emitter au lieu de vueMain.$emit, router.currentRoute.value.path)
- Fix syntaxe computed properties dans les objets
- Fix bug nom de variable (fightNotificationQueue)
- Ajout du type fight_notification à l'interface Events

## Test plan
- [ ] Lancer un combat et vérifier que les notifications de résultat ne s'affichent pas pendant le visionnage
- [ ] Vérifier que les notifications s'affichent bien en quittant la page du combat
- [ ] Vérifier que les notifications non-spoil (level up, etc.) s'affichent normalement

🤖 Generated with [Claude Code](https://claude.com/claude-code)