### PR TITLE
Fix extended chat going behind editor scrollbar (#809)

### DIFF
--- a/src/component/editor/ai-view-monaco.vue
+++ b/src/component/editor/ai-view-monaco.vue
@@ -393,7 +393,7 @@ export default class AIViewMonaco extends Vue {
 .ai {
 	min-width: 0;
 	height: 100%;
-	//position: relative;
+	position: relative;
 	& :deep(code) {
 		display: inline-flex !important;
 	}

--- a/src/component/editor/editor.vue
+++ b/src/component/editor/editor.vue
@@ -994,6 +994,7 @@
 		min-height: 0;
 		flex: 1;
 		display: flex;
+		isolation: isolate;
 	}
 	.popup.input_popup input {
 		width: 90%;


### PR DESCRIPTION
Add isolation: isolate to .editors container to create a stacking
context that contains Monaco editor's internal z-indexes, preventing
them from competing with the chat's z-index: 1000. Also restore
position: relative on the .ai wrapper for proper overlay positioning.

https://claude.ai/code/session_01HR3Tay3eHPgLULwafVhjLx