### PR TITLE
Fix n_day translation: replace French "j" (jour) with correct day abbreviation per language

### DIFF
--- a/src/lang/da/main.json
+++ b/src/lang/da/main.json
@@ -270,7 +270,7 @@
 	"side_right": "Til højre",
 	"n_year": "1 år | {n} år",
 	"n_month": "1 måned | {n} måneder",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 d | {n} d",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/de/main.json
+++ b/src/lang/de/main.json
@@ -270,7 +270,7 @@
 	"side_right": "Rechts",
 	"n_year": "1 Jahr | {n} Jahre",
 	"n_month": "1 Monat | {n} Monate",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 T | {n} T",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/en/main.json
+++ b/src/lang/en/main.json
@@ -271,7 +271,7 @@
 	"side_right": "To the right",
 	"n_year": "1 year | {n} years",
 	"n_month": "1 month | {n} months",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 d | {n} d",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/es/main.json
+++ b/src/lang/es/main.json
@@ -270,7 +270,7 @@
 	"side_right": "A la derecha",
 	"n_year": "1 año | {n} años",
 	"n_month": "1 mes | {n} meses",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 d | {n} d",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/fi/main.json
+++ b/src/lang/fi/main.json
@@ -270,7 +270,7 @@
 	"side_right": "Oikealle",
 	"n_year": "1 vuosi | {n} vuotta",
 	"n_month": "1 kuukausi | {n} kuukautta",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 pv | {n} pv",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/id/main.json
+++ b/src/lang/id/main.json
@@ -270,7 +270,7 @@
 	"side_right": "Ke kanan",
 	"n_year": "1 tahun | {n} tahun",
 	"n_month": "1 bulan | {n} bulan",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 hr | {n} hr",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 menit | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/it/main.json
+++ b/src/lang/it/main.json
@@ -270,7 +270,7 @@
 	"side_right": "A destra",
 	"n_year": "1 anno | {n} anni",
 	"n_month": "1 mese | {n} mesi",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 g | {n} g",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/ja/main.json
+++ b/src/lang/ja/main.json
@@ -270,7 +270,7 @@
 	"side_right": "右へ",
 	"n_year": "1年｜{n}年",
 	"n_month": "1ヶ月｜{n}ヶ月",
-	"n_day": "1 j｜{n} j",
+	"n_day": "1日｜{n}日",
 	"n_hour": "1 h｜{n} h",
 	"n_minute": "1分｜{n}分",
 	"n_second": "1 s｜{n} s",

--- a/src/lang/ko/main.json
+++ b/src/lang/ko/main.json
@@ -270,7 +270,7 @@
 	"side_right": "오른쪽으로",
 	"n_year": "1년 | {n}년",
 	"n_month": "1개월 | {n}개월",
-	"n_day": "1 j | {n} j",
+	"n_day": "1일 | {n}일",
 	"n_hour": "1 시간 | {n} 시간",
 	"n_minute": "1분 | {n} 분",
 	"n_second": "1초 | {n}초",

--- a/src/lang/nl/main.json
+++ b/src/lang/nl/main.json
@@ -270,7 +270,7 @@
 	"side_right": "Naar rechts",
 	"n_year": "1 jaar | {n} jaar",
 	"n_month": "1 maand | {n} maanden",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 d | {n} d",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/no/main.json
+++ b/src/lang/no/main.json
@@ -270,7 +270,7 @@
 	"side_right": "Til høyre",
 	"n_year": "1 år | {n} år",
 	"n_month": "1 måned | {n} måneder",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 d | {n} d",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/pl/main.json
+++ b/src/lang/pl/main.json
@@ -270,7 +270,7 @@
 	"side_right": "W prawo",
 	"n_year": "1 rok | {n} lat",
 	"n_month": "1 miesiąc | {n} miesięcy",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 d | {n} d",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/pt/main.json
+++ b/src/lang/pt/main.json
@@ -270,7 +270,7 @@
 	"side_right": "Para a direita",
 	"n_year": "1 ano | {n} anos",
 	"n_month": "1 mês | {n} meses",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 d | {n} d",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/ru/main.json
+++ b/src/lang/ru/main.json
@@ -270,7 +270,7 @@
 	"side_right": "Направо",
 	"n_year": "1 год | {n} лет",
 	"n_month": "1 месяц | {n} месяцев",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 д | {n} д",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 мин | {n} мин",
 	"n_second": "1 s | {n} s",

--- a/src/lang/sv/main.json
+++ b/src/lang/sv/main.json
@@ -270,7 +270,7 @@
 	"side_right": "Till höger",
 	"n_year": "1 år | {n} år",
 	"n_month": "1 månad | {n} månader",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 d | {n} d",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",

--- a/src/lang/zh/main.json
+++ b/src/lang/zh/main.json
@@ -270,7 +270,7 @@
 	"side_right": "向右",
 	"n_year": "1 年 | {n} 年",
 	"n_month": "1 个月 | {n} 个月",
-	"n_day": "1 j | {n} j",
+	"n_day": "1 天 | {n} 天",
 	"n_hour": "1 h | {n} h",
 	"n_minute": "1 min | {n} min",
 	"n_second": "1 s | {n} s",


### PR DESCRIPTION
The n_day translation key used the French abbreviation "j" (jour) in all
16 non-French languages, making the day duration unreadable in trophy
rankings. Each language now uses its own proper abbreviation.

https://claude.ai/code/session_01QKqLaCGnA7AnLSjXSaCnS3