### PR TITLE
Fix beta language badges invisible in dark mode

### DIFF
--- a/src/component/app/header.vue
+++ b/src/component/app/header.vue
@@ -407,6 +407,7 @@
 	}
 	.beta {
 		background: white;
+		color: #333;
 		padding: 2px 4px;
 		border: 1px solid #aaa;
 		border-radius: 4px;

--- a/src/component/settings/settings.vue
+++ b/src/component/settings/settings.vue
@@ -536,6 +536,7 @@
 				top: -5px;
 				right: -5px;
 				background: var(--pure-white);
+				color: #333;
 				padding: 2px 4px;
 				border: 1px solid #aaa;
 				border-radius: 4px;


### PR DESCRIPTION
Add explicit text color to .beta badges so the "bêta" text remains
visible on the white background when using dark theme.

https://claude.ai/code/session_011zhmcnoMfg9itCwjDP4itB