### PR TITLE
fix: Guard against null access on farmerOpponents and teamOpponents in garden

### DIFF
--- a/src/component/garden/garden.vue
+++ b/src/component/garden/garden.vue
@@ -226,7 +226,7 @@
 										<garden-farmer :farmer="farmer" />
 									</span>
 								</div>
-								<div v-if="!farmerOpponents.length" class="no-opponent">
+								<div v-if="farmerOpponents && !farmerOpponents.length" class="no-opponent">
 									<img src="/image/notgood.png">
 									<h4>{{ $t('no_opponent_of_your_size') }}</h4>
 								</div>
@@ -258,7 +258,7 @@
 											<garden-compo :compo="compo" />
 										</span>
 									</div>
-									<div v-if="!teamOpponents[selectedComposition.id].length" class="no-opponent">
+									<div v-if="teamOpponents[selectedComposition.id] && !teamOpponents[selectedComposition.id].length" class="no-opponent">
 										<img src="/image/notgood.png">
 										<h4>{{ $t('no_opponent_of_your_size') }}</h4>
 									</div>


### PR DESCRIPTION
The recent mobile layout refactor moved the "no opponent" divs outside
their v-else blocks, causing crashes when data is still loading (null).
Added null checks before accessing .length.

https://claude.ai/code/session_01AXm5GkjPegvK7e1BNrMenR