### PR TITLE
Reset editor title to default when navigating back to AI list on mobile

### DIFF
--- a/src/component/editor/editor.vue
+++ b/src/component/editor/editor.vue
@@ -352,8 +352,8 @@
 					this.history.push(fileSystem.ais[id])
 				}
 			}
-			this.update()
 			LeekWars.setTitle(this.$t('title'), this.$t('n_ais', [fileSystem.aiCount]))
+			this.update()
 		}
 
 		mounted() {

--- a/src/component/editor/editor.vue
+++ b/src/component/editor/editor.vue
@@ -545,6 +545,7 @@
 					this.currentFolder = fileSystem.folderById[id]
 					this.currentType = 'folder'
 					explorer.selectFolder(this.currentFolder)
+					LeekWars.setTitle(this.$t('title'), this.$t('n_ais', [fileSystem.aiCount]))
 					LeekWars.splitShowList()
 					LeekWars.setActions(this.actions_list)
 				}
@@ -566,6 +567,7 @@
 			} else {
 				this.currentFolder = fileSystem.rootFolder
 				this.currentType = 'folder'
+				LeekWars.setTitle(this.$t('title'), this.$t('n_ais', [fileSystem.aiCount]))
 				LeekWars.splitShowList()
 				LeekWars.setActions(this.actions_list)
 			}


### PR DESCRIPTION
When returning to the explorer/folder view (via back button or folder
navigation), the title was not reset from the AI name back to the
generic "Editor" title. Add setTitle calls in both the folder and
mobile root folder branches of update().

https://claude.ai/code/session_016hTAY3QoYxFFtk4KRRqFPa