### PR TITLE
Fix "nouveau poireau" message shown when player already has 4 leeks

### DIFF
--- a/src/component/leek/level-dialog.vue
+++ b/src/component/leek/level-dialog.vue
@@ -83,7 +83,7 @@
 				<div>{{ $t('br_desc') }}</div>
 				<img class="screenshot" height=200 src="/image/feature/fight_battle_royale.webp" />
 			</div>
-			<div v-if="leek.level == 50 && Object.values($store.state.farmer.leeks).length === 4">
+			<div v-if="leek.level == 50 && Object.values($store.state.farmer.leeks).length < 4">
 				<h4><v-icon>mdi-leek</v-icon> {{ $t('main.new_leek') }}</h4>
 				<div>{{ $t('newleek_desc') }}</div>
 				<leek-image class="screenshot" :leek="{level: 1}" :scale="0.7" />


### PR DESCRIPTION
The level 50 unlock message for a new leek was shown when the farmer
had exactly 4 leeks (the maximum). Changed condition to only show the
message when the farmer has fewer than 4 leeks.

https://claude.ai/code/session_01EWkvYNYCCkZrbuRCQkJFN9