### PR TITLE
Fix resurrections not shown in health graph

### DIFF
--- a/src/component/report/report-life-chart.vue
+++ b/src/component/report/report-life-chart.vue
@@ -142,7 +142,7 @@
 			}
 			this.chartData = {
 				datasets: series.map((s, i) => ({
-					data: s.slice(0, s.findIndex((p: any) => p.y === 0 || p.y === null) + 1 || s.length),
+					data: s.slice(0, (s.findLastIndex((p: any) => p.y !== null && p.y !== 0) + 1) || s.length),
 					tension: this.smooth ? 0.2 : 0,
 					borderColor: TEAM_COLORS[this.filtered_entities[i].leek.team - 1],
 					label: this.filtered_entities[i].leek.translatedName,


### PR DESCRIPTION
The life chart was truncating data at the first death point using
findIndex, which cut off all data after a resurrection. Changed to
findLastIndex to find the last alive point instead, preserving
resurrection data while still trimming trailing dead periods.

https://claude.ai/code/session_01H48c9azjzj2gA1VNgEtzPg