### PR TITLE
feat: Add search bar to the market page

### DIFF
--- a/src/component/market/market.vue
+++ b/src/component/market/market.vue
@@ -3,6 +3,11 @@
 		<div class="page-header page-bar">
 			<h1>{{ $t('title') }}</h1>
 			<div class="tabs">
+				<div class="search-box">
+					<v-icon class="search-icon">mdi-magnify</v-icon>
+					<input v-model="search" type="text" :placeholder="$t('main.search')" class="search-input" @keyup.stop>
+					<v-icon v-if="search" class="search-clear" @click="search = ''">mdi-close</v-icon>
+				</div>
 				<div v-if="!LeekWars.mobile" class="tab action" @click="toggleExpanded">
 					<v-icon>{{ expanded ? 'mdi-arrow-collapse' : 'mdi-arrow-expand' }}</v-icon>
 				</div>
@@ -39,22 +44,22 @@
 		</div>
 		<div class="container">
 			<div v-show="!LeekWars.mobile || !LeekWars.splitBack" class="column8">
-				<panel v-if="$store.state.farmer?.buy_fights_enabled" :title="$t('fights')" icon="mdi-sword-cross">*
+				<panel v-if="$store.state.farmer?.buy_fights_enabled && filteredFightPacks.length" :title="$t('fights')" icon="mdi-sword-cross">
 					<template #content>
 						<loader v-if="!fight_packs.length" />
 						<div v-else class="items fights">
-							<router-link v-for="pack in fight_packs" :key="pack.id" v-ripple :to="'/market/' + pack.name" :farmer-count="0" :leek-count="0" class="item fight-pack">
+							<router-link v-for="pack in filteredFightPacks" :key="pack.id" v-ripple :to="'/market/' + pack.name" :farmer-count="0" :leek-count="0" class="item fight-pack">
 								<img :src="'/image/fight-pack/fight_pack_' + pack.fights + '.png'">
 								<div>{{ pack.title }}</div>
 							</router-link>
 						</div>
 					</template>
 				</panel>
-				<panel :title="$t('weapons') + ' [' + weapons.length + ']'" icon="mdi-pistol">
+				<panel v-if="filteredWeapons.length || !search" :title="$t('weapons') + ' [' + filteredWeapons.length + ']'" icon="mdi-pistol">
 					<template #content>
 						<loader v-if="!weapons.length" />
 						<div v-else class="items weapons">
-							<router-link v-for="weapon in weapons" :key="weapon.id" v-ripple :to="'/market/' + weapon.name.replace('weapon_', '')" class="item weapon" :class="{toohigh: weapon.level > max_level}">
+							<router-link v-for="weapon in filteredWeapons" :key="weapon.id" v-ripple :to="'/market/' + weapon.name.replace('weapon_', '')" class="item weapon" :class="{toohigh: weapon.level > max_level}">
 								<img :src="'/image/' + weapon.name.replace('_', '/') + '.png'">
 								<div v-if="items[weapon.id].leek_count || items[weapon.id].farmer_count" class="counts">
 									<span v-if="items[weapon.id].leek_count" class="leek-count">{{ items[weapon.id].leek_count }}</span>
@@ -64,7 +69,7 @@
 						</div>
 					</template>
 				</panel>
-				<panel :title="$t('chips') + ' [' + chips.length + ']'" icon="mdi-chip">
+				<panel v-if="filteredChips.length || !search" :title="$t('chips') + ' [' + filteredChips.length + ']'" icon="mdi-chip">
 					<template #actions>
 						<div class="button flat" @click="updateChipMode">
 							<v-icon v-if="chipMode === 'type'">mdi-sort-descending</v-icon>
@@ -73,8 +78,8 @@
 					</template>
 					<template #content>
 						<loader v-if="!chips.length" />
-						<div v-else-if="chipMode === 'level'" class="items chips">
-							<router-link v-for="chip in chips" :key="chip.id" v-ripple :to="'/market/' + chip.name" class="item chip" :class="{toohigh: chip.level > max_level}">
+						<div v-else-if="chipMode === 'level' || search" class="items chips">
+							<router-link v-for="chip in filteredChips" :key="chip.id" v-ripple :to="'/market/' + chip.name" class="item chip" :class="{toohigh: chip.level > max_level}">
 								<img :src="'/image/chip/' + chip.name + '.png'">
 								<div v-if="items[chip.id].leek_count || items[chip.id].farmer_count" class="counts">
 									<span v-if="items[chip.id].leek_count" class="leek-count">{{ items[chip.id].leek_count }}</span>
@@ -98,11 +103,11 @@
 						</div>
 					</template>
 				</panel>
-				<panel :title="$t('potions') + ' [' + potions.length + ']'" icon="mdi-bottle-tonic-plus-outline">
+				<panel v-if="filteredPotions.length || !search" :title="$t('potions') + ' [' + filteredPotions.length + ']'" icon="mdi-bottle-tonic-plus-outline">
 					<template #content>
 						<loader v-if="!potions.length" />
 						<div v-else class="items potions">
-							<router-link v-for="potion in potions" :key="potion.id" v-ripple :to="'/market/' + potion.name" class="item potion" :class="{toohigh: potion.level > max_level}">
+							<router-link v-for="potion in filteredPotions" :key="potion.id" v-ripple :to="'/market/' + potion.name" class="item potion" :class="{toohigh: potion.level > max_level}">
 								<img :src="'/image/potion/' + potion.name + '.png'">
 								<div v-if="items[potion.id].leek_count || items[potion.id].farmer_count" class="counts">
 									<span v-if="items[potion.id].leek_count" class="leek-count">{{ items[potion.id].leek_count }}</span>
@@ -112,11 +117,11 @@
 						</div>
 					</template>
 				</panel>
-				<panel :title="$t('hats') + ' [' + hats.length + ']'" icon="mdi-hat-fedora">
+				<panel v-if="filteredHats.length || !search" :title="$t('hats') + ' [' + filteredHats.length + ']'" icon="mdi-hat-fedora">
 					<template #content>
 						<loader v-if="!hats.length" />
 						<div v-else class="items hats">
-							<router-link v-for="hat in hats" :key="hat.id" v-ripple :to="'/market/' + hat.name" class="item hat" :class="{toohigh: hat.level > max_level}">
+							<router-link v-for="hat in filteredHats" :key="hat.id" v-ripple :to="'/market/' + hat.name" class="item hat" :class="{toohigh: hat.level > max_level}">
 								<img :src="'/image/hat/' + hat.name + '.png?2'">
 								<div v-if="items[hat.id].leek_count || items[hat.id].farmer_count" class="counts">
 									<span v-if="items[hat.id].leek_count" class="leek-count">{{ items[hat.id].leek_count }}</span>
@@ -126,11 +131,11 @@
 						</div>
 					</template>
 				</panel>
-				<panel :title="$t('pomps') + ' [' + pomps.length + ']'" icon="mdi-auto-fix">
+				<panel v-if="filteredPomps.length || !search" :title="$t('pomps') + ' [' + filteredPomps.length + ']'" icon="mdi-auto-fix">
 					<template #content>
 						<loader v-if="!pomps.length" />
 						<div v-else class="items pomps">
-							<router-link v-for="pomp in pomps" :key="pomp.id" :to="'/market/' + pomp.name" class="item pomp" :class="{toohigh: pomp.level > max_level}">
+							<router-link v-for="pomp in filteredPomps" :key="pomp.id" :to="'/market/' + pomp.name" class="item pomp" :class="{toohigh: pomp.level > max_level}">
 								<img :src="'/image/pomp/' + pomp.name + '.png'">
 								<div v-if="items[pomp.id].leek_count || items[pomp.id].farmer_count" class="counts">
 									<span v-if="items[pomp.id].leek_count" class="leek-count">{{ items[pomp.id].leek_count }}</span>
@@ -360,12 +365,39 @@
 		pomps: PompTemplate[] = []
 		request: any = null
 		onKeyDown: ((e: KeyboardEvent) => void) | null = null
+		search: string = ''
 
 		get max_level() {
 			if (store.state.farmer) {
 				return Math.max(...Object.values(store.state.farmer.leeks).map((l: any) => l.level))
 			}
 			return 0
+		}
+
+		matchesSearch(item: ItemTemplate): boolean {
+			if (!this.search) { return true }
+			const query = this.search.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+			const name = this.translateName(item).toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+			return name.includes(query)
+		}
+
+		get filteredFightPacks() {
+			return this.fight_packs.filter(p => this.matchesSearch(p))
+		}
+		get filteredWeapons() {
+			return this.weapons.filter(w => this.matchesSearch(this.items[w.id]))
+		}
+		get filteredChips() {
+			return this.chips.filter(c => this.matchesSearch(this.items[c.id]))
+		}
+		get filteredPotions() {
+			return this.potions.filter(p => this.matchesSearch(this.items[p.id]))
+		}
+		get filteredHats() {
+			return this.hats.filter(h => this.matchesSearch(this.items[h.id]))
+		}
+		get filteredPomps() {
+			return this.pomps.filter(p => this.matchesSearch(this.items[p.id]))
 		}
 
 		get orderedItemNames(): string[] {
@@ -911,6 +943,39 @@
 			img {
 				vertical-align: bottom;
 				width: 75px;
+			}
+		}
+	}
+	.search-box {
+		display: flex;
+		align-items: center;
+		background: var(--background);
+		border-radius: 4px;
+		padding: 0 8px;
+		margin-right: 8px;
+		flex: 1;
+		max-width: 300px;
+		.search-icon {
+			color: var(--text-color-secondary);
+			font-size: 20px;
+			margin-right: 4px;
+		}
+		.search-input {
+			border: none;
+			outline: none;
+			background: transparent;
+			color: var(--text-color);
+			font-size: 14px;
+			flex: 1;
+			min-width: 0;
+			height: 36px;
+		}
+		.search-clear {
+			cursor: pointer;
+			font-size: 18px;
+			color: var(--text-color-secondary);
+			&:hover {
+				color: var(--text-color);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds a search input in the market header that filters items across all categories (weapons, chips, potions, hats, pomps, fight packs)
- Search matches against translated item names, accent-insensitive
- Categories with no matches are hidden during search

Closes #2486

## Test plan
- [ ] Type a weapon name (e.g. "pistolet") → only matching weapons shown
- [ ] Type a chip name → matching chips shown, non-matching categories hidden
- [ ] Type with accents or without (e.g. "épée" / "epee") → both work
- [ ] Clear search with X button → all items restored
- [ ] Verify keyboard navigation still works after search

🤖 Generated with [Claude Code](https://claude.com/claude-code)