### PR TITLE
Retirer le + devant le bonus cristaux dans la banque

### DIFF
--- a/src/component/bank/bank-product.vue
+++ b/src/component/bank/bank-product.vue
@@ -9,7 +9,7 @@
 					<b>{{ product.crystals }}</b><b v-if="firstPurchase" class="x2-crystals"> + {{ product.crystals }}</b>
 				</template>
 			</i18n-t>
-			<span v-if="product.bonus" class="bonus-badge">+{{ firstPurchase ? product.bonus * 2 : product.bonus }} <span class="crystal"></span> {{ $t('offered') }}</span>
+			<span v-if="product.bonus" class="bonus-badge">{{ firstPurchase ? product.bonus * 2 : product.bonus }} <span class="crystal"></span> {{ $t('offered') }}</span>
 		</div>
 		<v-btn :variant="preview ? 'outlined' : 'flat'" color="#1976d2" class="buy-button" :to="preview ? undefined : '/bank/buy/' + index" :disabled="preview" prepend-icon="mdi-cart-outline">
 			<span v-if="LeekWars.currencies[LeekWars.currency].prefix"><span class="symbol">{{ LeekWars.currencies[LeekWars.currency].symbol }}</span>{{ format(product.prices[LeekWars.currency]) }}</span>


### PR DESCRIPTION
Le titre du pack contient déjà le bonus, le + portait à confusion.

https://claude.ai/code/session_01Vc7MmoUcrJoSt4me2B5psX