### PR TITLE
feat(debug): add debug option to show only player's actions

### DIFF
--- a/src/component/player/game/game.ts
+++ b/src/component/player/game/game.ts
@@ -393,6 +393,7 @@ class Game {
 	public displayDebugs: boolean = true
 	public displayAllyDebugs: boolean = true
 	public displayAILines: boolean = true
+	public debugOnlyMine: boolean = false
 	public plainBackground: boolean = false
 	public sound: boolean = false
 	public volume: number = 0.5;
@@ -1187,6 +1188,23 @@ class Game {
 							delete this.markersText[m]
 						}
 					}
+				}
+			}
+			// Si debugOnlyMine est activé, on saute toutes les actions des autres joueurs en appelant requestJump sur le prochain tour du joueur courant
+			const me = store.state.farmer ? store.state.farmer.id : null
+			if (this.debugOnlyMine && me != null && entity && entity.farmer && entity.farmer.id !== me) {
+				this.stopAllSounds()
+				let i = this.currentAction + 1
+				for (; i < this.actions.length; i++) {
+					if (this.actions[i].type !== ActionType.LEEK_TURN) continue
+					const nextLeekId = this.actions[i].params[1]
+					const nextLeek = this.leeks[nextLeekId]
+					if (nextLeek != null && nextLeek.farmer != null && nextLeek.farmer.id === me) {
+						break
+					}
+				}
+				if (i < this.actions.length) {
+					if (!this.jumping) this.requestJump(i)
 				}
 			}
 			this.actionDone()

--- a/src/component/player/player.da.i18n
+++ b/src/component/player/player.da.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Lyd aktiveret",
 	"sound_disactivated": "Dæmpet lyd",
 	"tactic_mode": "Taktisk tilstand",
+	"debug_only_my_leeks": "Mine handlinger",
 	"error_secret_trophy": "Denne kamp indeholder et hemmeligt trofæ, som du ikke har låst op for endnu."
 }

--- a/src/component/player/player.de.i18n
+++ b/src/component/player/player.de.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Ton aktiviert",
 	"sound_disactivated": "Gedämpfter Ton",
 	"tactic_mode": "Taktischer Modus",
+	"debug_only_my_leeks": "Meine Aktionen",
 	"error_secret_trophy": "Dieser Kampf enthält eine geheime Trophäe, die Sie noch nicht freigeschaltet haben."
 }

--- a/src/component/player/player.en.i18n
+++ b/src/component/player/player.en.i18n
@@ -34,5 +34,6 @@
 	"sound_disactivated": "Sound is off",
 	"clear_marks": "Clear mark()",
 	"tactic_mode": "Tactical mode",
+	"debug_only_my_leeks": "My actions",
 	"error_secret_trophy": "This fight contains a secret trophy you haven't unlocked yet."
 }

--- a/src/component/player/player.es.i18n
+++ b/src/component/player/player.es.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Sonido activado",
 	"sound_disactivated": "Sonido silenciado",
 	"tactic_mode": "Modo táctico",
+	"debug_only_my_leeks": "Mis acciones",
 	"error_secret_trophy": "Esta batalla contiene un trofeo secreto que aún no has desbloqueado."
 }

--- a/src/component/player/player.fi.i18n
+++ b/src/component/player/player.fi.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Ääni aktivoitu",
 	"sound_disactivated": "Mykistetty ääni",
 	"tactic_mode": "Taktinen tila",
+	"debug_only_my_leeks": "Omat toiminnot",
 	"error_secret_trophy": "Tämä taistelu sisältää salaisen palkinnon, jota et ole vielä avannut."
 }

--- a/src/component/player/player.fr.i18n
+++ b/src/component/player/player.fr.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Son activé",
 	"sound_disactivated": "Son coupé",
 	"clear_marks": "Effacer les mark()",
+	"debug_only_my_leeks": "Mes actions",
 	"tactic_mode": "Mode tactique"
 }

--- a/src/component/player/player.hi.i18n
+++ b/src/component/player/player.hi.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "ध्वनि सक्रिय",
 	"sound_disactivated": "मौन ध्वनि",
 	"tactic_mode": "सामरिक मोड",
+	"debug_only_my_leeks": "मेरी क्रियाएँ",
 	"error_secret_trophy": "इस लड़ाई में एक गुप्त ट्रॉफी है जिसे आपने अभी तक अनलॉक नहीं किया है।"
 }

--- a/src/component/player/player.id.i18n
+++ b/src/component/player/player.id.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Suara diaktifkan",
 	"sound_disactivated": "Suara diam",
 	"tactic_mode": "Modus Taktis",
+	"debug_only_my_leeks": "Aksi saya",
 	"error_secret_trophy": "Pertempuran ini berisi trofi rahasia yang belum Anda buka."
 }

--- a/src/component/player/player.it.i18n
+++ b/src/component/player/player.it.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Suono attivato",
 	"sound_disactivated": "Suono silenziato",
 	"tactic_mode": "Modalità tattica",
+	"debug_only_my_leeks": "Le mie azioni",
 	"error_secret_trophy": "Questa battaglia contiene un trofeo segreto che non avete ancora sbloccato."
 }

--- a/src/component/player/player.ja.i18n
+++ b/src/component/player/player.ja.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "サウンドが有効化されました",
 	"sound_disactivated": "消音",
 	"tactic_mode": "戦術モード",
+	"debug_only_my_leeks": "自分の動作",
 	"error_secret_trophy": "この戦いには、まだアンロックされていない秘密のトロフィーがある。"
 }

--- a/src/component/player/player.ko.i18n
+++ b/src/component/player/player.ko.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "소리 켜짐",
 	"sound_disactivated": "소리 꺼짐",
 	"tactic_mode": "전술 모드",
+	"debug_only_my_leeks": "내 동작",
 	"error_secret_trophy": "이 전투에는 아직 잠금 해제하지 않은 비밀 트로피가 있습니다."
 }

--- a/src/component/player/player.nl.i18n
+++ b/src/component/player/player.nl.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Geluid geactiveerd",
 	"sound_disactivated": "Gedempt geluid",
 	"tactic_mode": "Tactische modus",
+	"debug_only_my_leeks": "Mijn acties",
 	"error_secret_trophy": "Dit gevecht bevat een geheime trofee die je nog niet hebt vrijgespeeld."
 }

--- a/src/component/player/player.no.i18n
+++ b/src/component/player/player.no.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Lyd aktivert",
 	"sound_disactivated": "Dempet lyd",
 	"tactic_mode": "Taktisk modus",
+	"debug_only_my_leeks": "Mine handlinger",
 	"error_secret_trophy": "Denne kampen inneholder et hemmelig trofé som du ikke har låst opp ennå."
 }

--- a/src/component/player/player.pl.i18n
+++ b/src/component/player/player.pl.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Aktywowany dźwiękiem",
 	"sound_disactivated": "Wyciszony dźwięk",
 	"tactic_mode": "Tryb taktyczny",
+	"debug_only_my_leeks": "Moje akcje",
 	"error_secret_trophy": "Ta bitwa zawiera sekretne trofeum, którego jeszcze nie odblokowałeś."
 }

--- a/src/component/player/player.pt.i18n
+++ b/src/component/player/player.pt.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Som ativado",
 	"sound_disactivated": "Som mudo",
 	"tactic_mode": "Modo tático",
+	"debug_only_my_leeks": "Minhas ações",
 	"error_secret_trophy": "Esta batalha contém um troféu secreto que ainda não desbloqueaste."
 }

--- a/src/component/player/player.ru.i18n
+++ b/src/component/player/player.ru.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Звук активирован",
 	"sound_disactivated": "Приглушенный звук",
 	"tactic_mode": "Тактический режим",
+	"debug_only_my_leeks": "Мои действия",
 	"error_secret_trophy": "В этой битве есть секретный трофей, который вы еще не открыли."
 }

--- a/src/component/player/player.sv.i18n
+++ b/src/component/player/player.sv.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "Ljud aktiverat",
 	"sound_disactivated": "Dämpat ljud",
 	"tactic_mode": "Taktiskt läge",
+	"debug_only_my_leeks": "Mina handlingar",
 	"error_secret_trophy": "Den här striden innehåller en hemlig trofé som du inte har låst upp ännu."
 }

--- a/src/component/player/player.vue
+++ b/src/component/player/player.vue
@@ -229,6 +229,9 @@
 								<v-list-item v-if="!LeekWars.mobile" :ripple="game.showLifes" :class="{disabled: !game.showLifes}" prepend-icon="mdi-key" @click="game.showLifes ? (game.showIDs = !game.showIDs) : null">
 									<v-switch :model-value="game.showIDs" :disabled="!game.showLifes" :label="$t('show_ids') + ' (I)'" hide-details />
 								</v-list-item>
+								<v-list-item v-ripple prepend-icon="mdi-bug" @click="game.debugOnlyMine = !game.debugOnlyMine">
+									<v-switch :model-value="game.debugOnlyMine" :label="$t('debug_only_my_leeks') + ' (M)'" hide-details />
+								</v-list-item>
 							</v-list>
 						</v-menu>
 					</template>
@@ -346,6 +349,7 @@
 	if (localStorage.getItem('fight/actions') === null) localStorage.setItem('fight/actions', 'true')
 	if (localStorage.getItem('fight/auto-dark') === null) localStorage.setItem('fight/auto-dark', 'true')
 	if (localStorage.getItem('fight/debugs') === null) localStorage.setItem('fight/debugs', 'true')
+	if (localStorage.getItem('fight/debug-only-mine') === null) localStorage.setItem('fight/debug-only-mine', 'false')
 	game.value.shadows = localStorage.getItem('fight/shadows') === 'true'
 	game.value.tactic = localStorage.getItem('fight/tactic') === 'true'
 	game.value.showCells = localStorage.getItem('fight/cells') === 'true'
@@ -362,6 +366,7 @@
 	game.value.plainBackground = localStorage.getItem('fight/plain-background') === 'true'
 	game.value.displayDebugs = localStorage.getItem('fight/debugs') === 'true'
 	game.value.displayAILines = localStorage.getItem('fight/debug-lines') === 'true'
+	game.value.debugOnlyMine = localStorage.getItem('fight/debug-only-mine') === 'true'
 	game.value.displayAllyDebugs = localStorage.getItem('fight/ally-debugs') === 'true'
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	;(game.value as any).player = { gameLaunched, $emit: emit }
@@ -714,6 +719,10 @@
 	watch(() => game.value.plainBackground, () => { localStorage.setItem('fight/plain-background', '' + game.value.plainBackground); resize() })
 	watch(() => game.value.displayDebugs, () => { localStorage.setItem('fight/debugs', '' + game.value.displayDebugs) })
 	watch(() => game.value.displayAILines, () => { localStorage.setItem('fight/debug-lines', '' + game.value.displayAILines) })
+	watch(() => game.value.debugOnlyMine, () => {
+		localStorage.setItem('fight/debug-only-mine', '' + game.value.debugOnlyMine)
+		game.value.redraw()
+	})
 	watch(() => game.value.displayAllyDebugs, () => { localStorage.setItem('fight/ally-debugs', '' + game.value.displayAllyDebugs) })
 
 	function canvasClick() { game.value.selectEntity(game.value.click()) }

--- a/src/component/player/player.zh.i18n
+++ b/src/component/player/player.zh.i18n
@@ -34,5 +34,6 @@
 	"sound_activated": "声音激活",
 	"sound_disactivated": "静音",
 	"tactic_mode": "战术模式",
+	"debug_only_my_leeks": "我的动作",
 	"error_secret_trophy": "这场战斗包含一个您尚未解锁的秘密奖杯。"
 }


### PR DESCRIPTION
### Feature: ajout du mode debugOnlyMine

Ajout d’un mode `debugOnlyMine` permettant de filtrer la lecture du replay afin de n’afficher que les actions des leeks du joueur courant.

#### Fonctionnement
- Les actions des leeks ennemis sont ignorées pendant le replay
- Le système avance automatiquement jusqu’au prochain `LEEK_TURN` appartenant au joueur
- Le replay reste cohérent sans interrompre la simulation globale

#### Implémentation
- Ajout d’une logique de skip dans `LEEK_TURN`
- Recherche du prochain tour appartenant au joueur courant
- Avancement contrôlé via `requestJump` sans casser le flux de replay

#### Résultat
- Permet d’analyser uniquement ses actions
- Accélère la lecture des combats en mode debug
- Aucun impact sur le mode normal

#### Notes
- Les messages de documentation et les traductions ont été générés à l’aide d’une IA
- Le code a été écrit manuellement