### PR TITLE
fix(client): corrige l'affichage du "/" dans la tooltip d'XP du poireau

### DIFF
--- a/src/component/leek/leek.vue
+++ b/src/component/leek/leek.vue
@@ -104,7 +104,7 @@
 					<template v-else-if="leek">
 						<b>{{ $t('remaining_xp', [LeekWars.formatNumber(remaining_xp)]) }} ({{ Math.round(100 * (leek.xp - leek.down_xp) / (leek.up_xp - leek.down_xp)) }}%)</b>
 						<br>
-						{{ $t('xp', [LeekWars.formatNumber(leek.xp) + " / " + LeekWars.formatNumber(leek.up_xp)]) }}
+						{{ $t('xp', [LeekWars.formatNumber(leek.xp)]) }} / {{ LeekWars.formatNumber(leek.up_xp) }}
 					</template>
 				</v-tooltip>
 


### PR DESCRIPTION
Le "/" séparant l'XP courante de l'XP du niveau suivant était concaténé dans le paramètre passé à $t('xp', ...). Avec escapeParameter: true (vue-i18n), ce paramètre est échappé par escapeHtml, qui transforme "/" en &#x2F; ; l'entité s'affichait alors littéralement puisque la tooltip est rendue en texte.

<img width="336" height="125" alt="image" src="https://github.com/user-attachments/assets/995917a3-5aa3-4b6c-99da-4b8c86f049ec" />

On sort le "/" du paramètre i18n pour le rendre comme littéral du template, comme partout ailleurs dans le code.