### PR TITLE
Fix nombre de registres maximal incorrect

### DIFF
--- a/src/component/leek/leek.vue
+++ b/src/component/leek/leek.vue
@@ -299,7 +299,7 @@
 		</div>
 
 		<panel v-if="leek && my_leek && leek.registers && leek.registers.length > 0" toggle="leek/registers" icon="mdi-database">
-			<template #title>{{ $t('registers') }} <span class="register-count">[{{ leek.registers.length }}/100]</span></template>
+			<template #title>{{ $t('registers') }} <span class="register-count">[{{ leek.registers.length }}/101]</span></template>
 			<table class="registers">
 				<tr>
 					<th>{{ $t('register_key') }}</th>


### PR DESCRIPTION
La limite effective est 101, même si l'affichage montre [nb_registres/100]. Cette PR change l'affichage.