### PR TITLE
Replace console.log with a leveled logger utility (#771)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,7 @@ export default tseslint.config(
 	{
 		files: ['**/*.ts', '**/*.vue'],
 		rules: {
+			'no-console': ['error', { allow: ['warn', 'error'] }],
 			'@typescript-eslint/no-inferrable-types': 'off',
 			'@typescript-eslint/explicit-module-boundary-types': 'off',
 			'@typescript-eslint/no-unused-vars': ['error', {
@@ -99,4 +100,10 @@ export default tseslint.config(
 	},
 
 	eslintConfigPrettier,
+	{
+		files: ['**/*.test.ts'],
+		rules: {
+			'no-console': 'off',
+		},
+	},
 )

--- a/src/component/app/console.vue
+++ b/src/component/app/console.vue
@@ -168,13 +168,11 @@ function down() {
 onMounted(() => {
 	emitter.on('console', (raw: unknown) => {
 		const data = raw as Omit<ConsoleLine, 'type'>
-		console.log("on console", data)
 		lines.value.push({ type: 'result', ...data })
 		scrollDown()
 	})
 	emitter.on('console-error', (raw: unknown) => {
 		const data = raw as Omit<ConsoleLine, 'type'>
-		console.log("on console-error", data)
 		let zigzags = ""
 		if (data.location) {
 			for (let i = 0; i < data.location[2]; ++i) zigzags += ' '
@@ -184,7 +182,6 @@ onMounted(() => {
 		scrollDown()
 	})
 	emitter.on('console-log', (data: unknown) => {
-		console.log("on console-log", data)
 		lines.value.push({ type: 'log', log: data as unknown[] })
 		scrollDown()
 	})

--- a/src/component/bank/bank-buy.vue
+++ b/src/component/bank/bank-buy.vue
@@ -69,6 +69,7 @@ import { cspNonce } from '@/component/editor/monaco-csp'
 import BankProduct from './bank-product.vue'
 import Breadcrumb from '@/component/forum/breadcrumb.vue'
 import { store } from '@/model/store'
+import { logger } from '@/utils/logger'
 
 defineOptions({ name: 'Bank', i18n: {}, mixins: [...mixins] })
 
@@ -219,11 +220,11 @@ function loadPayPal() {
 			},
 			onError: (err) => {
 				LeekWars.post('bank/track-payment-abort', { order_id: '', reason: 'error' })
-				console.error('PayPal button error', err)
+				logger.error('PayPal button error', err)
 			}
 		}).render('#paypal-button-container')
 	}).catch((err) => {
-		console.error('failed to load the PayPal JS SDK script', err)
+		logger.error('failed to load the PayPal JS SDK script', err)
 	})
 }
 

--- a/src/component/creator/creator.vue
+++ b/src/component/creator/creator.vue
@@ -315,7 +315,6 @@ function addEntity(mob: MapPlayer) {
 function edited(_info: string) {
 	if (saveTimeout) clearTimeout(saveTimeout)
 	saveTimeout = setTimeout(() => {
-		console.log("save...")
 		if (!map.value) return
 
 		const g = playerRef.value!.game

--- a/src/component/editor/analyzer.ts
+++ b/src/component/editor/analyzer.ts
@@ -9,6 +9,7 @@ import { Problem } from './problem'
 import { i18n } from '@/model/i18n'
 import * as monaco from 'monaco-editor'
 import { markRaw, reactive } from 'vue'
+import { logger } from '@/utils/logger'
 
 const ERROR_UNUSED_VARIABLE = 148
 const ERROR_UNUSED_FUNCTION = 152
@@ -87,7 +88,6 @@ class Analyzer {
 		this.promise = new Promise((resolve) => {
 			const Module: { onRuntimeInitialized?: () => void; ccall?: (name: string) => void } = {
 				onRuntimeInitialized: () => {
-					// console.log("Module initialized", Module)
 					Module.ccall!('init')
 					// this.GeneratorAnalyze = Module.cwrap('analyze', 'string', ['boolean', 'string', 'string', 'boolean'])
 					// this.GeneratorComplete = Module.cwrap('complete', 'string', ['boolean', 'string', 'number'])
@@ -96,9 +96,6 @@ class Analyzer {
 					// this.GeneratorAddEntrypoint = Module.cwrap('addEntrypoint', 'void', ['boolean', 'string', 'boolean', 'string'])
 					// this.getExceptionMessage = Module.cwrap('getExceptionMessage', 'string', ['number'])
 					// this.GeneratorDelete = Module.cwrap('delete_', 'string', ['string'])
-
-					// console.log(this.GeneratorAnalyze(false, "Fight.toto"))
-					// console.log(this.GeneratorComplete(false, "Fight.getEntity().name", 18))
 
 					resolve(null)
 				}
@@ -115,7 +112,6 @@ class Analyzer {
 		for (const entrypoint in this.problems) {
 			for (const ai in this.problems[entrypoint]) {
 				const problems = this.problems[entrypoint][ai]
-				// console.log(this.problems[ai])
 				for (const problem of problems) {
 					if (problem.level === 0) { errors++ }
 					else if (problem.level === 1) { warnings++ }
@@ -150,7 +146,6 @@ class Analyzer {
 	}
 
 	public analyze(ai: AI, code: string) {
-		// console.log("🔥 Analyze", ai.path)
 		// console.time('hover')
 
 		// Seul LeekScript passe par le daemon. Les polyglot sont validés CÔTÉ CLIENT et remontés via le
@@ -310,7 +305,6 @@ class Analyzer {
 	}
 
 	public hover(ai: AI, line: number, column: number) {
-		// console.log("🔥 Hover", ai.path, line, column)
 		// console.time('hover')
 		LeekWars.socket.send([SocketMessage.EDITOR_HOVER, ai.path, line, column])
 
@@ -334,7 +328,6 @@ class Analyzer {
 		}
 
 		const requestID = this.requestID++
-		// console.log("Complete request", requestID)
 		LeekWars.socket.send([SocketMessage.EDITOR_COMPLETE, requestID, ai.path, code, line, column])
 
 		const promise = new Promise<CompletionResult | null>((resolve) => {
@@ -366,9 +359,7 @@ class Analyzer {
 	}
 
 	public completeResult(message: {type: number, id: number, data: unknown}) {
-		// console.log("complete result", message)
 		if (this.completeResolve[message.id]) {
-			// console.log("resolve complete", message)
 			// console.timeEnd('hover')
 			this.completeResolve[message.id](message.data)
 			delete this.completeResolve[message.id]
@@ -382,14 +373,14 @@ class Analyzer {
 
 		return this.promise.then(() => {
 
-			console.log("🔥 Delete", ai.path)
+			logger.debug("🔥 Delete", ai.path)
 
 			this.running = 1
 			return new Promise((resolve, reject) => setTimeout(() => {
 				try {
 					console.time("delete")
 					const result = JSON.parse(this.GeneratorDelete(ai.path))
-					console.log(result)
+					logger.debug(result)
 					for (const path in result) {
 						const problems = result[path]
 						problems.sort((a: any, b: any) => {
@@ -402,7 +393,6 @@ class Analyzer {
 					const problems = [ [0, 0, 0, 0, 1, "ANALYZER_CRASHED"] ]
 					// this.setAIProblems(ai.path, problems)
 					try {
-						// console.error(this.getExceptionMessage(e))
 					} catch (e2) {
 						// nothing
 					}
@@ -422,14 +412,11 @@ class Analyzer {
 		for (const entrypoint_id of ai.entrypoints) {
 			const entrypoint = fileSystem.ais[entrypoint_id]
 			if (entrypoint) {
-				// console.log("Add entrypoint", ai.path, "==>", entrypoint.path)
 				this.GeneratorAddEntrypoint(ai.version, ai.path, entrypoint.version, entrypoint.path)
 			}
 		}
 	}
 	*/
-
-
 
 	handleProblems(entrypoint: AI, problems: unknown[][]) {
 
@@ -508,7 +495,6 @@ class Analyzer {
 	}
 
 	public setProblems(entrypoint: string, ai: AI, problems: Problem[]) {
-		// console.log("[Analyzer] set ai problems", entrypoint, ai, problems)
 		if (!(entrypoint in this.problems)) {
 			this.problems[entrypoint] = {}
 		}
@@ -723,7 +709,7 @@ class Analyzer {
 	private loadJs(url: string) {
 		return new Promise((resolve, reject) => {
 			if (document.querySelector(`head > script[ src = "${url}" ]`) !== null) {
-				console.warn(`script already loaded: ${url}`)
+				logger.warn(`script already loaded: ${url}`)
 				resolve(null)
 			}
 			const script = document.createElement("script")

--- a/src/component/editor/explorer.ts
+++ b/src/component/editor/explorer.ts
@@ -9,7 +9,6 @@ class Explorer {
 	public selectedFolder!: Folder
 
 	public selectAI(ai: AI) {
-		// console.log("select ai", ai)
 		if (this.selectedAI) {
 			this.selectedAI.selected = false
 			if (this.selectedFolder) {
@@ -26,7 +25,6 @@ class Explorer {
 	}
 
 	public selectFolder(folder: Folder) {
-		// console.log("select folder", folder)
 		if (this.selectedFolder) {
 			this.selectedFolder.selected = false
 		}
@@ -43,13 +41,11 @@ class Explorer {
 	}
 
 	public setExpanded(folder: Folder, expanded: boolean) {
-		// console.log("folder", folder.name, "expanded", expanded)
 		folder.expanded = expanded
 		localStorage.setItem('editor/folder/' + folder.id, '' + folder.expanded)
 	}
 
 	public setClosed(folder: Folder, closed: boolean) {
-		// console.log("folder", folder.name, "expanded", expanded)
 		folder.closed = closed
 		localStorage.setItem('editor/folder/closed/' + folder.id, '' + folder.closed)
 	}

--- a/src/component/editor/monaco.ts
+++ b/src/component/editor/monaco.ts
@@ -131,7 +131,6 @@ function methodNameFromLine(lineContent: string): string | null {
 	return name
 }
 
-
 monaco.editor.defineTheme("leek-wars", {
 	base: "vs", // can also be vs-dark or hc-black
 	inherit: true, // can also be false to completely replace the builtin rules
@@ -256,7 +255,6 @@ monaco.languages.registerHoverProvider("leekscript", {
 		if (!ai) { return classHoverFor(word, position) }
 
 		const hover = await analyzer.hover(ai, position.lineNumber, position.column - 1)
-		// console.log(hover)
 		// this.hover = hover
 		if (hover && hover.type) {
 			const range = new monaco.Range(
@@ -489,7 +487,6 @@ monaco.languages.registerCompletionItemProvider('python', {
 
 monaco.languages.registerDefinitionProvider("leekscript", {
 	provideDefinition: async (model, position, _token) => {
-		// console.log("provideDefinition", model.uri.path, position.lineNumber, position.column)
 
 		// Make a fresh hover request instead of using potentially stale lastHover
 		const ai = fileSystem.aiByFullPath[model.uri.path.substring(1)]
@@ -497,7 +494,6 @@ monaco.languages.registerDefinitionProvider("leekscript", {
 		const hover = await analyzer.hover(ai, position.lineNumber, position.column - 1)
 
 		if (hover?.defined) {
-			// console.log("provideDefinition defined", hover.defined)
 			const range = new monaco.Range(
 				hover.defined[1],
 				hover.defined[2] + 1,
@@ -838,8 +834,6 @@ LeekWars.completionsProvider = monaco.languages.registerCompletionItemProvider("
 
 	provideCompletionItems: async function (model, position) {
 
-		// console.log("provideCompletionItems", model)
-
 		const path = model.uri.path.substring(1)
 		const ai = fileSystem.getAIByPath(path)
 		if (!ai) { return { suggestions: [] } }
@@ -850,7 +844,6 @@ LeekWars.completionsProvider = monaco.languages.registerCompletionItemProvider("
 		const line = model.getLineContent(position.lineNumber)
 		const isDot = line.charAt(word.startColumn - 2) === '.'
 		const tokenBeforeDot = model.getWordAtPosition({ column: word.startColumn - 1, lineNumber: position.lineNumber })?.word || ''
-		// console.log("word", word, "isDot", isDot, "tokenBeforeDot", tokenBeforeDot)
 		const range = {
 			startLineNumber: position.lineNumber,
 			endLineNumber: position.lineNumber,
@@ -867,7 +860,6 @@ LeekWars.completionsProvider = monaco.languages.registerCompletionItemProvider("
 
 		const visited = new Set<string>()
 		const maybeAdd = (data: string | Keyword) => {
-			// console.log("keyword", data)
 			if (typeof data === 'string') {
 				if (data.toLowerCase().indexOf(word.word.toLowerCase()) === 0) {
 					suggestions.push({

--- a/src/component/editor/pyright-client.ts
+++ b/src/component/editor/pyright-client.ts
@@ -28,6 +28,7 @@ const TYPESHED_FILES: Record<string, string> = Object.fromEntries(
 )
 // Worker prébuilt (IIFE webpack). ?worker -> Vite émet le chunk et fournit le constructeur.
 import PyrightWorker from '@typefox/pyright-browser/dist/pyright.worker.js?worker'
+import { logger } from '@/utils/logger'
 
 // En DEV, Vite sert le worker en module (un `import "/@vite/env"` est injecté en tête) : le worker
 // principal (type module) boote, mais les threads d'analyse de fond que Pyright spawne LUI-MÊME
@@ -111,7 +112,6 @@ function mapDiagnostics(diagnostics: Diagnostic[]): monaco.editor.IMarkerData[] 
 	}))
 }
 
-
 // --- Fichiers du joueur dans la FS du worker ---
 // Les IA .py peuvent s'importer entre elles (le generator monte les fichiers du joueur sous /ai en
 // tête de sys.path, sous-dossiers = packages). Pour que Pyright résolve ces imports (complétion,
@@ -143,7 +143,7 @@ async function loadPlayerPyFiles(out: Record<string, string>): Promise<void> {
 			out['/' + ai.path] = ai.model ? ai.model.getValue() : ((await fileSystem.load(ai)).code ?? '')
 		} catch (e) {
 			// Non monté : ses importeurs verront « import non résolu » (reportMissingImports) -> tracer.
-			console.warn('[pyright] seed impossible pour', ai.path, e)
+			logger.warn('[pyright] seed impossible pour', ai.path, e)
 		}
 	}))
 }
@@ -170,7 +170,7 @@ async function seedFile(path: string): Promise<void> {
 	try {
 		code = ai.model ? ai.model.getValue() : ((await fileSystem.load(ai)).code ?? '')
 	} catch (e) {
-		console.warn('[pyright] seed impossible pour', path, e)
+		logger.warn('[pyright] seed impossible pour', path, e)
 		return
 	}
 	// Re-vérifie APRÈS l'await : un renommage/suppression pendant le chargement rendrait ce montage
@@ -213,13 +213,13 @@ function ensure(): Promise<void> {
 		const filesAcc: Record<string, string> = {} // rempli au fil de l'eau par loadPlayerPyFiles
 		const playerFilesPromise = loadPlayerPyFiles(filesAcc) // chargement en parallèle du boot
 		const worker = await createWorker()
-		worker.onerror = (e) => { console.error('[pyright] worker error', e.message || e); teardown() }
+		worker.onerror = (e) => { logger.error('[pyright] worker error', e.message || e); teardown() }
 		// Le worker prébuilt attend un message de boot pour se câbler en serveur (mode foreground) ;
 		// les threads d'analyse de fond se ré-instancient eux-mêmes (cf BrowserWorkersHost).
 		worker.postMessage({ type: 'browser/boot', mode: 'foreground' })
 		const conn = createMessageConnection(new BrowserMessageReader(worker), new BrowserMessageWriter(worker))
 		connection = conn
-		conn.onError((e) => console.error('[pyright] connection error', e))
+		conn.onError((e) => logger.error('[pyright] connection error', e))
 		conn.onClose(() => { if (connection === conn) teardown() })
 
 		// Pyright pousse les diagnostics via cette notification.
@@ -269,7 +269,7 @@ function ensure(): Promise<void> {
 		})
 		conn.sendNotification('initialized', {})
 		conn.sendNotification('workspace/didChangeConfiguration', { settings: { python: { analysis: pySettings() } } })
-	})().catch((e) => { console.error('[pyright] init failed', e); teardown(); throw e })
+	})().catch((e) => { logger.error('[pyright] init failed', e); teardown(); throw e })
 	return ready
 }
 
@@ -436,7 +436,7 @@ export async function completePy(model: monaco.editor.ITextModel, position: mona
 			position: lspPosition(position),
 		})
 	} catch (e) {
-		console.error('[pyright] completion failed', e)
+		logger.error('[pyright] completion failed', e)
 		return null
 	}
 	if (!result) return null
@@ -498,7 +498,7 @@ export async function hoverPy(model: monaco.editor.ITextModel, position: monaco.
 	try {
 		h = await connection.sendRequest('textDocument/hover', { textDocument: { uri }, position: lspPosition(position) })
 	} catch (e) {
-		console.error('[pyright] hover failed', e)
+		logger.error('[pyright] hover failed', e)
 		return null
 	}
 	if (!h) return null
@@ -519,7 +519,7 @@ export async function definitionPy(model: monaco.editor.ITextModel, position: mo
 	try {
 		d = await connection.sendRequest('textDocument/definition', { textDocument: { uri }, position: lspPosition(position) })
 	} catch (e) {
-		console.error('[pyright] definition failed', e)
+		logger.error('[pyright] definition failed', e)
 		return null
 	}
 	const loc = Array.isArray(d) ? d[0] : d

--- a/src/component/inventory/inventory.vue
+++ b/src/component/inventory/inventory.vue
@@ -174,6 +174,7 @@
 	import ItemPreview from '@/component/market/item-preview.vue'
 	import SchemeImage from '../market/scheme-image.vue'
 	import { emitter } from '@/model/vue'
+	import { logger } from '@/utils/logger'
 
 	enum Sort {
 		DATE, PRICE, PRICE_LOT, QUANTITY, /*NAME, */ LEVEL, RARITY
@@ -277,7 +278,7 @@
 	function withKnownTemplate<T extends { template: number }>(items: T[]): T[] {
 		return items.filter(item => {
 			if (item.template in LeekWars.items) return true
-			console.warn('[inventory] template inconnu, objet ignoré :', item.template)
+			logger.warn('[inventory] template inconnu, objet ignoré :', item.template)
 			return false
 		})
 	}

--- a/src/component/player/game/chest.ts
+++ b/src/component/player/game/chest.ts
@@ -89,7 +89,6 @@ class Chest extends FightEntity {
 		// Body
 		const width = this.bodyTexFront.texture.width
 		const height = this.bodyTexFront.texture.height
-		// console.log(this.growth, width, height)
 		const y = height * (this.deadAnim - 1)
 		// Rectangle source dégénéré (image pas encore chargée → width 0, ou deadAnim == 1
 		// en début de blooming → hauteur 0) : drawImage lève IndexSizeError sur Safari. On

--- a/src/component/player/game/chips.ts
+++ b/src/component/player/game/chips.ts
@@ -1638,7 +1638,6 @@ class BoxingGlove extends ChipAnimation {
 		}
 		// Find real end cell
 		this.cell = this.game.ground.field.getLastAvailableCell(entity_cell, this.cell, targets[0])
-		// console.log("end cell", this.cell)
 		const xy = this.game.ground.field.cellToXY(this.cell)
 		this.position = this.game.ground.xyToXYPixels(xy.x, xy.y)
 		const target_distance = Math.sqrt(Math.pow(launchPos.x - this.tsx, 2) + Math.pow(launchPos.y - this.tsy, 2))

--- a/src/component/player/game/entity.ts
+++ b/src/component/player/game/entity.ts
@@ -14,6 +14,7 @@ import { Path } from './path'
 import { S } from './sound'
 import { WeaponAnimation } from './weapons'
 import { HatTemplate } from '@/model/hat'
+import { logger } from '@/utils/logger'
 
 enum EntityType {
 	LEEK = 0,
@@ -226,7 +227,7 @@ abstract class FightEntity extends Entity {
 
 	public setCell(cell: Cell) {
 		if (cell === null) {
-			console.trace("Cell is null")
+			logger.warn("Cell is null")
 		}
 		cell.setEntity(this)
 		this.cell = cell
@@ -320,7 +321,6 @@ abstract class FightEntity extends Entity {
 	}
 
 	public updateReachableCells() {
-		// console.log("update reachable cells", this.name)
 
 		this.reachableCells.clear()
 
@@ -352,7 +352,6 @@ abstract class FightEntity extends Entity {
 			}
 			grow = new_cells
 		}
-		// console.log(Array.from(this.reachableCells).map(cell => cell.id))
 
 		this.reachableCellsArea = this.game.createReachableAreaOutline(this.mp, this.cell!, this.reachableCells)
 	}
@@ -944,8 +943,6 @@ abstract class FightEntity extends Entity {
 		const rotation2 = 0.023
 		const f2dy = 0
 		this.game.particles.addGarbage(f2_x, this.oy - 15, f2_z - 15, f2dx, f2dy, fdz, fragment2, 1, rotation2, f_scale, 0, 70)
-
-		// console.log({ topX, topY, bottomX, bottomY, cx, cy })
 
 		const s_top = s * (1 + cy / h - 0.5)
 		this.game.particles.addLineParticle(

--- a/src/component/player/game/game.ts
+++ b/src/component/player/game/game.ts
@@ -30,6 +30,7 @@ import { WeaponTemplate } from '@/model/weapon'
 import { Chest } from './chest'
 import { Mob } from './mob'
 import { Turret } from './turret'
+import { logger } from '@/utils/logger'
 
 /** Anything the game loop can draw on a canvas row */
 interface Drawable {
@@ -501,7 +502,7 @@ class Game {
 	public init(fight: Fight) {
 
 		if (this.initialized) {
-			console.warn("Déjà initialisé !")
+			logger.warn("Déjà initialisé !")
 			return
 		}
 
@@ -511,7 +512,7 @@ class Game {
 
 		// Check data
 		if (this.data == null) {
-			console.warn("Fight is null...")
+			logger.warn("Fight is null...")
 			this.setError()
 			return
 		}
@@ -537,7 +538,6 @@ class Game {
 			const o = this.obstacles[i]
 			if (this.data.map.id) { // Map fixe
 				const info = OBSTACLES[o as unknown as number]
-				// console.log("add obstacle", o, info)
 				const obstacle = new Obstacle(this, info.geometry, this.ground.field.cells[parseInt(i, 10)], info!)
 				obstacle.resize()
 				this.ground.addObstacle(obstacle)
@@ -545,7 +545,6 @@ class Game {
 				const _type = o instanceof Array ? o[0] : -2
 				const size = o instanceof Array ? o[1] : o // Before the obstacle was an array [type, size]
 				if (size !== -1) {
-					// console.log({ type, size })
 					const types = size === 2 ? this.map.options.largeObstacles.length : this.map.options.smallObstacles.length
 					const realType = this.map.random.next() * types | 0
 					const info = size === 1 ? this.map.options.smallObstacles[realType] : this.map.options.largeObstacles[realType]
@@ -811,9 +810,6 @@ class Game {
 					break
 			}
 		}
-		// console.log("used chips", chipsUsed)
-		// console.log("weapons taken", weaponsTaken)
-		// console.log("weapons used", weaponsUsed)
 
 		// Load common textures
 		T.tp.load(this)
@@ -859,8 +855,6 @@ class Game {
 		for (const sound of Fish.sounds) {
 			sounds.add(sound)
 		}
-		// console.log("textures to load", textures)
-		// console.log("sounds to load", sounds)
 		for (const texture of textures) {
 			texture.load(this)
 		}
@@ -921,7 +915,6 @@ class Game {
 			}
 		}
 
-		// console.log(this.leeks)
 		for (const leek of this.leeks) {
 			this.states[leek.id] = {
 				absoluteShield: 0,
@@ -1342,7 +1335,6 @@ class Game {
 					}
 				}
 				if (chip === 89) { // boxing glove
-					// console.log("glove", cell.id, "targets=" + targets.length)
 					if (targets.length && !targets[0].states.has(State.STATIC)) {
 						const realCell = this.ground.field.getLastAvailableCell(caster.cell!, cell, targets[0])
 						realCell.setEntity(targets[0])
@@ -1415,7 +1407,6 @@ class Game {
 				break
 			}
 
-			// console.log(leek.weapon, weapon_template)
 			const targets = this.ground.field.getTargets(cell, weapon_template.area, leek.cell!, weapon_template.max_range, weapon_template.min_range) as FightEntity[]
 
 			const duration = leek.useWeapon(cell, targets, result)
@@ -1498,7 +1489,6 @@ class Game {
 					const angle = Math.atan2(dy, dx)
 					const ndx = Math.cos(angle)
 					const ndy = Math.sin(angle)
-					// console.log("dx", dx, "dy", dy, "angle", angle, "ndx", ndx, "ndy", ndy)
 					entity.kill(true, killer.lastDamageType, ndx, ndy) // Animation
 				} else {
 					entity.kill(true, DamageType.DEFAULT, 0, 0) // Animation
@@ -1701,7 +1691,7 @@ class Game {
 			break
 		}
 		default: {
-			console.warn("Erreur : action inconnue", action)
+			logger.warn("Erreur : action inconnue", action)
 			this.actionDone()
 		}
 		}
@@ -1732,8 +1722,6 @@ class Game {
 	}
 
 	public addEffect(action: Action, stacked: boolean) {
-
-		// console.log("addEffect", action, stacked)
 
 		const item = action.params[1]
 		const id = action.params[2]
@@ -2165,7 +2153,6 @@ class Game {
 	}
 
 	public mousedown(_e: MouseEvent) {
-		// console.log("game mousedown")
 		if (this.creator) {
 			if (this.groundPaint) {
 				this.painting = true
@@ -2173,7 +2160,6 @@ class Game {
 				const obstacle = this.ground.obstacles.find(o => o.cell === this.mouseCell)
 				if (obstacle) {
 					this.draggedObstacle = obstacle
-					// console.log("game dragged=", this.draggedObstacle)
 				}
 				const entity = this.leeks.find(e => e.cell === this.mouseCell)
 				if (entity) {
@@ -2254,17 +2240,14 @@ class Game {
 		}
 		if (this.creator) {
 			if (this.draggedObstacle && this.mouseCell && this.ground.field.canFit(this.draggedObstacle, this.mouseCell)) {
-				// console.log("move draggedObstacle", this.paused)
 				this.draggedObstacle.move(this.mouseCell)
 				this.player.$emit('edited', 'obstacle' + this.draggedObstacle.drawID)
 			}
 			if (this.draggedEntity && this.mouseCell && this.mouseCell.isAvailable()) {
-				// console.log("move draggedObstacle", this.paused)
 				this.draggedEntity.setCell(this.mouseCell)
 				this.player.$emit('edited', 'entity' + this.draggedEntity.drawID)
 			}
 			if (this.painting && this.groundPaint && this.mouseCell) {
-				// console.log("change cell color", this.mouseCell, this.map.options)
 				const paint = this.groundPaint.texture === this.map.options.groundTexture ? 0 : this.groundPaint.id
 				if (this.mouseCell.color !== paint) {
 					this.mouseCell.color = paint
@@ -2281,7 +2264,6 @@ class Game {
 	public click() {
 		if (this.creator) {
 			if (this.groundPaint && this.mouseCell) {
-				// console.log("change cell color", this.mouseCell, this.map.options)
 				const paint = this.groundPaint.texture === this.map.options.groundTexture ? 0 : this.groundPaint.id
 				if (this.mouseCell.color !== paint) {
 					this.mouseCell.color = paint
@@ -2303,7 +2285,6 @@ class Game {
 			this.draggedEntity = null
 
 			const obstacle = this.ground.obstacles.find(o => o.cell === this.mouseCell)
-			// console.log("obstacle found", obstacle)
 			if (obstacle) {
 				this.removeObstacle(obstacle)
 				this.ground.resize(this.width, this.height, this.shadows)
@@ -2359,13 +2340,11 @@ class Game {
 	}
 
 	public addObstacle(obstacle: Obstacle) {
-		// console.log("addObstacle", obstacle.y)
 		this.ground.obstacles.push(obstacle)
 		obstacle.drawID = this.addDrawableElement(obstacle, obstacle.y)
 	}
 
 	public removeObstacle(obstacle: Obstacle) {
-		// console.log("removeObstacle", obstacle.y)
 		for (const coord of obstacle.geometry.cells) {
 			const cell = this.ground.field.next_cell(obstacle.cell, coord[0], coord[1])
 			if (cell) { cell.obstacle = null }
@@ -2390,16 +2369,14 @@ class Game {
 	}
 
 	public addDrawableElement(element: Drawable, line: number): number {
-		// console.log("add drawable element")
 		this.drawableElementCurrentId++
 		this.drawableElements[line][this.drawableElementCurrentId] = element
 		return this.drawableElementCurrentId
 	}
 
 	public moveDrawableElement(element: Drawable, id: number, line: number, newLine: number) {
-		// console.log("move drawable element")
 		if (!this.drawableElements[newLine]) {
-			console.warn("Error moving object to line " + newLine)
+			logger.warn("Error moving object to line " + newLine)
 			return
 		}
 		this.drawableElements[newLine][id] = element // Ajout de l'élément sur la nouvelle ligne
@@ -2410,10 +2387,9 @@ class Game {
 		// if (this.drawableElements[line] !== undefined) {
 		// 	if (this.drawableElements[line][id] != null) {
 				if (!this.drawableElements[line][id]) {
-					console.log("No drawable element to remove", id, line)
-					console.log(this.drawableElements)
+					logger.warn("No drawable element to remove", id, line)
+					logger.warn(this.drawableElements)
 				} else {
-				// 	console.log("remove", this.drawableElements[line][id])
 					delete this.drawableElements[line][id]
 				}
 		// 	}
@@ -2997,7 +2973,6 @@ class Game {
 
 	public drawGroundPaint() {
 		if (this.groundPaint) {
-			// console.log("drawGroundPaint", this.groundPaint)
 			const x = this.mouseX!
 			const y = this.mouseY!
 			const size = this.ground.tileSizeY
@@ -3205,7 +3180,6 @@ class Game {
 	public resourceLoaded(_res: string) { // variable utile pour débug
 		this.loadedData++
 		if (this.cancelled) { return }
-		// console.log("Resource loaded : " + res + " (" + this.loadedData + "/" + this.numData + ")")
 		if (this.loadedData === this.numData && this.initialized === true) {
 			if (!this.launched) {
 				this.launch() // Start game if all resources are loaded

--- a/src/component/player/game/leek.ts
+++ b/src/component/player/game/leek.ts
@@ -132,8 +132,6 @@ class Leek extends FightEntity {
 	public kill(animation: boolean, damageType: DamageType, dx: number, dy: number) {
 		super.kill(animation, damageType, dx, dy)
 
-		// console.log("kill", "dx", dx, "dy", dy)
-
 		if (animation) {
 			// Throw hat
 			if (this.hat && damageType === DamageType.DEFAULT) {

--- a/src/component/player/game/obstacle.ts
+++ b/src/component/player/game/obstacle.ts
@@ -59,7 +59,6 @@ class Obstacle {
 		// Caractéristiques
 		this.geometry = geometry
 		this.info = info
-		// console.log("obstacle", info)
 		// Position
 		const pos = game.ground.field.cellToXY(cell)
 		this.x = pos.x
@@ -68,14 +67,12 @@ class Obstacle {
 	}
 
 	public updateType() {
-		// console.log("update type")
 		const obstacles = this.geometry.id === 2 ? this.game.map.options.largeObstacles : this.game.map.options.smallObstacles
 		this.info = obstacles[this.game.map.random.next() * obstacles.length | 0]!
 	}
 
 	public resize() {
 		// Create the cache texture
-		// console.log("type=", this.type)
 		// const textureType = this.size === 2 ? this.game.map.options.largeObstacles : this.game.map.options.smallObstacles
 		this.baseTexture = this.pumpkin ? T.pumpkin : this.info.texture
 
@@ -132,7 +129,6 @@ class Obstacle {
 	}
 
 	public draw(ctx: CanvasRenderingContext2D) {
-		// console.log("obstacle draw()", this.baseTexture)
 		if (this.game.tactic) {
 
 			const H = 8 * this.game.ground.scale
@@ -251,7 +247,6 @@ class Obstacle {
 		this.cell = cell
 		this.resize()
 		if (oldY !== this.y) {
-			// console.log("move obstacle", oldY, this.y)
 			this.game.moveDrawableElement(this, this.drawID!, oldY, this.y)
 			this.game.ground.resize(this.game.width, this.game.height, this.game.shadows)
 		}

--- a/src/component/player/game/particle.ts
+++ b/src/component/player/game/particle.ts
@@ -1032,14 +1032,12 @@ class BuryParticle extends Particle {
 		super(game, x, y, 0, BuryParticle.LIFE)
 		this.texture = texture
 		this.scale = scale
-		// console.log("texture", game, x, y, texture, texture.texture.width, texture.texture.height)
 	}
 
 	public draw(ctx: CanvasRenderingContext2D): void {
 		const w = this.texture.texture.width
 		const h = (this.life / BuryParticle.LIFE) * this.texture.texture.height
 		// const h = this.texture.texture.height
-		// console.log("draw", this.x, this.y, w, h)
 		ctx.drawImage(this.texture.texture, 0, 0, w, h, - w / 2 * this.scale, - h * this.scale, w * this.scale, h * this.scale)
 	}
 }

--- a/src/component/player/game/texture.ts
+++ b/src/component/player/game/texture.ts
@@ -1,5 +1,6 @@
 import { Game } from '@/component/player/game/game'
 import { LeekWars } from '@/model/leekwars'
+import { logger } from '@/utils/logger'
 
 const SHADOW_QUALITY = 0.3
 
@@ -65,7 +66,7 @@ class Texture {
 		// compter la ressource deux fois (loadedData est comparé à numData par
 		// égalité stricte, un dépassement bloquerait le chargement pour toujours).
 		const onerror = () => {
-			console.warn("Error loading : " + this.path)
+			logger.warn("Error loading : " + this.path)
 			listeners.abort()
 			const image = this.texture
 			// Une Image en échec reste dans l'état « broken » : drawImage lèverait
@@ -534,7 +535,7 @@ function loadDrawableImage(src: string): HTMLImageElement {
 	}
 	const image = new Image()
 	const onerror = () => {
-		console.warn("Error loading : " + image.src)
+		logger.warn("Error loading : " + image.src)
 		image.src = TRANSPARENT_PIXEL
 	}
 	image.addEventListener('error', onerror, { once: true })
@@ -565,7 +566,7 @@ function buildTextureShadow(texture: Texture, quality: number) {
 		context.putImageData(newTexture, 0, 0)
 		texture.shadow = canvas
 	} catch (e) {
-		console.error("Failed to create texture!", e)
+		logger.error("Failed to create texture!", e)
 	}
 }
 

--- a/src/component/report/statistics.ts
+++ b/src/component/report/statistics.ts
@@ -176,7 +176,6 @@ class FightStatistics {
 
 		for (const action of fight.data.actions) {
 			const type = action[0] as ActionType
-			// console.log(action)
 			switch (type) {
 				case ActionType.NEW_TURN: {
 					// Possible d'avoir des action new_turn deux fois de suite (bug corrigé)
@@ -205,7 +204,6 @@ class FightStatistics {
 						switch (effect.type) {
 							case EffectType.POISON: {
 								const value = Math.max(0, Math.min(life, effect.value))
-								// console.log("poison from", caster, value)
 								caster.poison_out += value
 								caster.nova_out += Math.round(value * 0.1)
 								entity.poison_in += value

--- a/src/component/workshop/workshop.vue
+++ b/src/component/workshop/workshop.vue
@@ -133,9 +133,7 @@
 		})
 	})
 
-	console.log("LeekWars.schemes", LeekWars.schemes)
 	schemes.value = Object.values(LeekWars.schemes)
-	console.log("Schemes", schemes.value)
 
 	onMounted(() => {
 		LeekWars.footer = false

--- a/src/model/ai.ts
+++ b/src/model/ai.ts
@@ -12,6 +12,7 @@ import { i18n } from './i18n'
 import { Keyword, KeywordKind, LSClass } from './keyword'
 import { LeekWars } from './leekwars'
 import type * as monaco from 'monaco-editor'
+import { logger } from '@/utils/logger'
 
 class AI {
 	public name!: string
@@ -58,8 +59,6 @@ class AI {
 
 		if (!isLeekScript(this.path)) return
 
-		// console.log("analyze", this.path)
-
 		try {
 			this.updateIncludes()
 
@@ -76,31 +75,24 @@ class AI {
 			}
 			this.comments = comments
 
-			// console.log("Comments", comments)
-
 			this.updateFunctions()
 			this.updateClasses()
 			this.updateGlobalVars()
 		} catch (e) {
-			console.error("analyze failed", this.path, e)
+			logger.error("analyze failed", this.path, e)
 		}
 	}
 
 	public updateIncludes() {
-		// console.log("Update includes", this.path, ('' + this.code).substring(0, 100))
 		// console.time("inc")
 		this.includes = []
 		const regex = /include\s*\(\s*["'](.*?)["']\s*\)/gm
 		let m
 		while ((m = regex.exec(this.code))) {
 			const path = m[1]
-			// console.log(m)
 			const included = fileSystem.find(path, this.folder)
 			if (included) {
-				// console.log("Found included", path, this.folder, included)
 				this.includes.push(included)
-			} else {
-				// console.warn("Included not found", path, this.ai.folder, included)
 			}
 		}
 		// console.timeEnd("inc")
@@ -145,12 +137,10 @@ class AI {
 
 		while ((match = regex.exec(this.code)) != null) {
 
-			// console.log(match)
 			const line = this.code.substring(0, match.index).split("\n").length
 			const return_type = match[3] ? match[3].trim() : 'any'
 
 			const { args, types } = this.parseArguments(match[2])
-			// console.log(args, types)
 
 			let fullName = match[1] + "(" + args.join(", ") + ")"
 			let description = "<h4>" + i18n.t('leekscript.function_f', [fullName]) + "</h4><br>"
@@ -162,21 +152,18 @@ class AI {
 				description: "",
 				items: [] as JavadocItem[],
 			}
-			// console.log(javadoc)
 			// Add arguments from signature
 			let a = 0
 			for (const arg of args) {
 				javadoc.items.push({ type: 'param', name: arg, text: null, lstype: { name: types[a] } })
 				a++
 			}
-			// console.log(javadoc.items)
 			if (comment) {
 				const javadoc_lines = comment.split("\n")
 				const javadoc_regex = /^\s*@(\w+)(?:\s+([a-zA-Z0-9_\u00C0-\u024F\u1E00-\u1EFF]+)\s*:?\s*)?(?:\s*:\s*)?(.*)$/
 				let match_javadoc
 				for (const jline of javadoc_lines) {
 					if ((match_javadoc = javadoc_regex.exec(jline))) {
-						// console.log(match_javadoc)
 						const type = match_javadoc[1]
 						let name = match_javadoc[2]
 						let text = match_javadoc[3]
@@ -194,9 +181,7 @@ class AI {
 								text = text.trim().substring(1)
 							}
 							if (args.includes(name) || args.includes(text)) {
-								// console.log('arg', name, text)
 								const existing = javadoc.items.find(i => i.type === 'param' && ((name.length && i.name === name) || (text.length && i.name === text)))
-								// console.log('existing', existing)
 								// existing.name = existing.text
 								if (existing) existing.text = text
 								continue
@@ -212,7 +197,6 @@ class AI {
 						}
 					}
 				}
-				// console.log("javadoc", javadoc)
 			}
 
 			// Escape
@@ -236,7 +220,6 @@ class AI {
 				category: 4,
 				return_type: { name: return_type }
 			}
-			// console.log(fun)
 			this.functions.push(fun)
 		}
 	}
@@ -283,7 +266,6 @@ class AI {
 				)
 			}
 		}
-		// console.log("Classes", this.ai.classes)
 		// console.timeEnd('classes')
 
 		// console.time('static_fields')
@@ -295,8 +277,6 @@ class AI {
 			const name = match[3]
 			if (name === 'function' || name === 'for' || name === 'while' || name === 'if') continue
 
-			// console.log(match[1], match[2], match[3])
-
 			const is_static = !!match[1]
 			const type = match[2]
 			const line = this.code.substring(0, match.index).split("\n").length
@@ -306,21 +286,18 @@ class AI {
 			description += i18n.t('leekscript.defined_in', [this.name, line])
 
 			const comment = this.comments[match.index] || this.comments[match.index + 1]
-			// console.log("comment", comment)
 			const javadoc = {
 				name: fullName,
 				description: "",
 				items: [] as JavadocItem[],
 				lstype: { name: type }
 			}
-			// console.log(javadoc.items)
 			if (comment) {
 				const javadoc_lines = comment.split("\n")
 				const javadoc_regex = /^\s*@(\w+)(?:\s+([a-zA-Z0-9_\u00C0-\u024F\u1E00-\u1EFF]+)\s*:?\s*)?(?:\s*:\s*)?(.*)$/
 				let match_javadoc
 				for (const jline of javadoc_lines) {
 					if ((match_javadoc = javadoc_regex.exec(jline))) {
-						// console.log(match_javadoc)
 						const type = match_javadoc[1]
 						const name = match_javadoc[2]
 						const text = match_javadoc[3]
@@ -334,7 +311,6 @@ class AI {
 						}
 					}
 				}
-				// console.log("javadoc", javadoc)
 			}
 
 			// Escape
@@ -381,9 +357,8 @@ class AI {
 			const name = match[3]
 			if (name === 'function' || name === 'for' || name === 'while' || name === 'if') continue
 
-			// console.log(match)
 			if (!name) {
-				console.error("No name", match)
+				logger.error("No name", match)
 			}
 			const is_static = !!match[1]
 			const return_type = match[2] ? match[2].trim() : 'any'
@@ -396,7 +371,6 @@ class AI {
 			description += i18n.t('leekscript.defined_in', [this.name, line])
 
 			const comment = this.comments[match.index] || this.comments[match.index + 1]
-			// console.log("comment", comment, this.comments, match)
 			const javadoc = {
 				name,
 				args,
@@ -409,14 +383,12 @@ class AI {
 				javadoc.items.push({ type: 'param', name: arg, text: null, lstype: { name: types[a] } })
 				a++
 			}
-			// console.log(javadoc.items)
 			if (comment) {
 				const javadoc_lines = comment.split("\n")
 				const javadoc_regex = /^\s*@(\w+)(?:\s+([a-zA-Z0-9_\u00C0-\u024F\u1E00-\u1EFF]+)\s*:?\s*)?(?:\s*:\s*)?(.*)$/
 				let match_javadoc
 				for (const jline of javadoc_lines) {
 					if ((match_javadoc = javadoc_regex.exec(jline))) {
-						// console.log(match_javadoc)
 						const type = match_javadoc[1]
 						let lstype: { name: string } | undefined = undefined
 						let name = match_javadoc[2]
@@ -436,9 +408,7 @@ class AI {
 								text = text.trim().substring(1)
 							}
 							if (args.includes(name) || args.includes(text)) {
-								// console.log('arg', name, text)
 								const existing = javadoc.items.find(i => i.type === 'param' && ((name.length && i.name === name) || (text.length && i.name === text)))
-								// console.log('existing', existing)
 								// existing.name = existing.text
 								if (existing) existing.text = text
 								continue
@@ -454,7 +424,6 @@ class AI {
 						}
 					}
 				}
-				// console.log("javadoc", javadoc)
 			}
 
 			// Escape
@@ -472,7 +441,7 @@ class AI {
 			}
 			if (clazz) {
 				if (!match[3]) {
-					console.error("No name", match)
+					logger.error("No name", match)
 				}
 				const method = {
 					label: match[3],
@@ -489,7 +458,6 @@ class AI {
 					clazz,
 					return_type: { name: return_type }
 				}
-				// console.log(fun)
 				if (is_static) {
 					clazz.static_methods.push(method)
 				} else {
@@ -498,7 +466,6 @@ class AI {
 			}
 		}
 
-		// console.log("classes " + this.name, this.classes)
 		// console.timeEnd('methods')
 		// console.trace()
 	}
@@ -529,14 +496,12 @@ class AI {
 	}
 
 	public isClassDefined(clazz: string): boolean {
-		// console.log("isClassDefined", clazz, this)
 
 		const visited = new Set<string>()
 
 		const aux = (ai: AI): boolean => {
 			if (visited.has(ai.path)) { return false }
 			visited.add(ai.path)
-			// console.log("aux", ai.path)
 
 			if (ai.classes[clazz]) return true
 
@@ -555,11 +520,9 @@ class AI {
 		const result = aux(this)
 		if (result) { return result }
 
-		// console.log("entrypoints", startAI.entrypoints)
 		for (const entrypoint_id of this.entrypoints) {
 			const entrypoint = fileSystem.ais[entrypoint_id]
 			if (entrypoint) {
-				// console.log("entrypoints", entrypoint.path, entrypoint.includes)
 				const result = aux(entrypoint)
 				if (result) { return result }
 			}
@@ -569,14 +532,11 @@ class AI {
 
 	public searchSymbol(symbol: string, previousToken: string | undefined): Keyword | null {
 
-		// console.log("searchSymbolInAI", symbol)
-
 		const visited = new Set<string>()
 
 		const aux = (ai: AI): Keyword | null => {
 			if (visited.has(ai.path)) { return null }
 			visited.add(ai.path)
-			// console.log("aux", ai.path)
 			if (ai.functions) {
 				for (const fun of ai.functions) {
 					if (symbol === fun.label) {
@@ -624,11 +584,9 @@ class AI {
 		const result = aux(this)
 		if (result) { return result }
 
-		// console.log("entrypoints", startAI.entrypoints)
 		for (const entrypoint_id of this.entrypoints) {
 			const entrypoint = fileSystem.ais[entrypoint_id]
 			if (entrypoint) {
-				// console.log("entrypoints", entrypoint.path, entrypoint.includes)
 				const result = aux(entrypoint)
 				if (result) { return result }
 			}

--- a/src/model/boss-squads.ts
+++ b/src/model/boss-squads.ts
@@ -55,7 +55,6 @@ export class BossSquads {
 	}
 	updateSquad(data: BossSquad) {
 		this.squad = data
-		// console.log("Update squad", data)
 		const leeks = this.squad!.engaged_leeks.filter(l => (l.farmer as unknown as number) === store.state.farmer!.id).map(l => l.id)
 		localStorage.setItem('garden/boss-leeks', JSON.stringify(leeks))
 		// this.enabled = true

--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -60,7 +60,6 @@ class Chat {
 	}
 
 	add(message: ChatMessage) {
-		// console.log("chat add", message, this)
 		if (this.messages.length && this.messages[this.messages.length - 1].id === message.id) return
 		this.prepare(message)
 		this.messages.push(message)
@@ -82,7 +81,6 @@ class Chat {
 	}
 
 	unshift(message: ChatMessage) {
-		// console.log("chat add", message, this)
 		this.prepare(message)
 		this.messages.unshift(message)
 

--- a/src/model/doc-signature.test.ts
+++ b/src/model/doc-signature.test.ts
@@ -216,7 +216,6 @@ describe('couverture de la table stdlib', () => {
 		// itertools.batched est du 3.12, JS n'a pas d'équivalent natif.
 		expect(enPY('arrayChunk')).not.toBeNull()
 		expect(enTS('arrayChunk')).toBeNull()
-		// console.warn existe en JS ; Python n'a pas de canal d'avertissement séparé.
 		expect(enTS('debugW')).not.toBeNull()
 		expect(enPY('debugW')).toBeNull()
 		// bitCount, lui, est désormais couvert des DEUX côtés via Math.

--- a/src/model/emitter.ts
+++ b/src/model/emitter.ts
@@ -76,6 +76,9 @@ const emitter = mitt<Events>()
 export let vueMain: ComponentPublicInstance | null = null
 export function setVueMain(vm: ComponentPublicInstance | null) { vueMain = vm }
 
+// Intentional player-facing message in the devtools console (scam warning + GitHub invite),
+// so it must stay a raw console.log and be visible in production.
+/* eslint-disable no-console */
 export function displayWarningMessage() {
 	const style = "color: black; font-size: 13px; font-weight: bold;"
 	const styleRed = "color: red; font-size: 14px; font-weight: bold;"
@@ -86,5 +89,6 @@ export function displayWarningMessage() {
 	console.log("%c✔️ " + i18n.t('main.console_github'), style)
 	console.log("")
 }
+/* eslint-enable no-console */
 
 export { emitter }

--- a/src/model/emojis.ts
+++ b/src/model/emojis.ts
@@ -56,7 +56,6 @@ function formatEmojis(rawData: unknown): string {
 	// Custom smileys
 	for (const i in Emojis.custom) {
 		const smiley = Emojis.custom[i]
-		// console.log("(^|\\s|>|\\))" + escapeRegExp(i))
 		data = data.replace(new RegExp(escapeRegExp(i), "gi"), (a: string, pos: number) => {
 			const previous = data.charAt(pos - 1)
 			if (pos === 0 || previous === ')' || previous === '>' || previous === ' ' || previous === '\xa0') {

--- a/src/model/field.ts
+++ b/src/model/field.ts
@@ -164,7 +164,6 @@ class Field {
 	}
 
 	public getTargets(center: Cell, area: Area, caster_cell: Cell, max_range: number, min_range: number = 1): Entity[] {
-		// console.log("getTargets", center, area, caster_cell)
 		if (area === Area.FIRST_INLINE) {
 			const cell = this.getFirstWithEntity(caster_cell, center, max_range, min_range)
 			if (cell) {
@@ -246,7 +245,6 @@ class Field {
 	}
 
 	public getLastAvailableCell(from: Cell, target: Cell, targetEntity: FightEntity) {
-		// console.log("getLastAvailableCell", "from=" + from.id, "target=" + target.id, "static=" + targetEntity.states.has(State.STATIC))
 		const dx = Math.sign(target.x - from.x)
 		const dy = Math.sign(target.y - from.y)
 		let current = from

--- a/src/model/gamedata.ts
+++ b/src/model/gamedata.ts
@@ -1,4 +1,5 @@
 import { getMany, setMany, createStore } from 'idb-keyval'
+import { logger } from '@/utils/logger'
 
 const idbStore = createStore('leek-wars-data', 'game-data')
 const LS_PREFIX = 'gd:'
@@ -65,7 +66,7 @@ async function loadFromIdb(skipVersionCheck = false): Promise<GameDataMap | null
 		if (!skipVersionCheck) {
 			const cookieVersion = getCookieMasterVersion()
 			if (cookieVersion && meta.master_version !== cookieVersion) {
-				console.warn(`[GameData] Version mismatch: IDB=${meta.master_version}, cookie=${cookieVersion} → invalidating cache`)
+				logger.warn(`[GameData] Version mismatch: IDB=${meta.master_version}, cookie=${cookieVersion} → invalidating cache`)
 				return null
 			}
 		}
@@ -73,7 +74,7 @@ async function loadFromIdb(skipVersionCheck = false): Promise<GameDataMap | null
 		const result: GameDataMap = {}
 		for (let i = 0; i < DATA_TYPES.length; i++) {
 			if (values[i + 1] == null) {
-				console.warn(`[GameData] Missing type '${DATA_TYPES[i]}' in IndexedDB → invalidating cache`)
+				logger.warn(`[GameData] Missing type '${DATA_TYPES[i]}' in IndexedDB → invalidating cache`)
 				return null
 			}
 			result[DATA_TYPES[i]] = values[i + 1]
@@ -90,8 +91,8 @@ function saveToIdb(masterVersion: string, hashes: { [key: string]: string }, dat
 		entries.push(['data:' + type, data[type]])
 	}
 	setMany(entries, idbStore)
-		.then(() => console.log(`[GameData] Saved to IndexedDB`))
-		.catch(e => console.warn('[GameData] IndexedDB save failed:', e))
+		.then(() => logger.info(`[GameData] Saved to IndexedDB`))
+		.catch(e => logger.warn('[GameData] IndexedDB save failed:', e))
 }
 
 // --- localStorage fallback ---
@@ -113,7 +114,7 @@ function loadFromLs(skipVersionCheck = false): GameDataMap | null {
 			if (item == null) return null
 			result[type] = JSON.parse(item)
 		}
-		console.log('[GameData] Loaded from localStorage (fallback)')
+		logger.info('[GameData] Loaded from localStorage (fallback)')
 		return result
 	} catch {
 		return null
@@ -143,7 +144,7 @@ export async function loadGameData(): Promise<GameDataMap | null> {
 
 	if (inline != null) {
 		const changedTypes = Object.keys(inline.data)
-		console.log(`[GameData] Inline: ${changedTypes.length} types changed, master_version=${inline.master_version}`)
+		logger.info(`[GameData] Inline: ${changedTypes.length} types changed, master_version=${inline.master_version}`)
 
 		cacheSave(inline.master_version, inline.hashes, inline.data)
 		updateCookie(inline.master_version, inline.hashes)
@@ -158,7 +159,7 @@ export async function loadGameData(): Promise<GameDataMap | null> {
 			}
 			// Aucun cache disponible → fetch complet (laisse l'erreur remonter si fetchAll échoue,
 			// retourner inline.data partiel laisserait LeekWars.hats/etc. vides → crash render).
-			console.warn('[GameData] No cache for unchanged types, fetching all from API...')
+			logger.warn('[GameData] No cache for unchanged types, fetching all from API...')
 			const full = await fetchAll()
 			for (const type of changedTypes) {
 				full[type] = inline.data[type]
@@ -169,17 +170,17 @@ export async function loadGameData(): Promise<GameDataMap | null> {
 	}
 
 	// __DATA__ null → tout est à jour, charger depuis le cache
-	console.log('[GameData] __DATA__ null, loading from cache...')
+	logger.info('[GameData] __DATA__ null, loading from cache...')
 	const t0 = performance.now()
 	const cached = await cacheLoad()
 	const dt = (performance.now() - t0).toFixed(1)
 
 	if (cached) {
-		console.log(`[GameData] Loaded from cache in ${dt}ms, master_version=${getCookieMasterVersion()}`)
+		logger.info(`[GameData] Loaded from cache in ${dt}ms, master_version=${getCookieMasterVersion()}`)
 		return cached
 	}
 
-	console.log('[GameData] No cache → fetching from API...')
+	logger.info('[GameData] No cache → fetching from API...')
 	return await fetchAll()
 }
 
@@ -190,7 +191,7 @@ async function fetchAll(): Promise<GameDataMap> {
 	const json = await response.json()
 
 	const data = json.data
-	console.log(`[GameData] Fetched ${Object.keys(data).length} types from API, master_version=${json.master_version}`)
+	logger.info(`[GameData] Fetched ${Object.keys(data).length} types from API, master_version=${json.master_version}`)
 
 	cacheSave(json.master_version, json.hashes, data)
 	updateCookie(json.master_version, json.hashes)

--- a/src/model/i18n.ts
+++ b/src/model/i18n.ts
@@ -2,6 +2,7 @@ import { locale as initialLocale, messages } from '@/locale'
 import type { Component, ComponentInstance } from 'vue'
 import { watch } from 'vue'
 import { createI18n } from 'vue-i18n'
+import { logger } from '@/utils/logger'
 
 // Pre-declare dynamic imports for Vite to bundle them
 const localeModules = import.meta.glob('/src/lang/locale/*.ts') as Record<string, () => Promise<{ translations: Record<string, unknown> }>>
@@ -149,17 +150,15 @@ function setI18nLanguage(lang: string) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function loadLanguageAsync(vue: any, newLocale: string) {
-	// console.log("loadLanguageAsync", newLocale)
 	const currentRoute = vue.$router.currentRoute.value?.matched[0]
 	if (currentRoute) {
-		// console.log("loadLanguageAsync", currentRoute)
 		loadComponentLanguage(newLocale, currentRoute.components?.default, currentRoute.instances?.default)
 	}
 	if (!loadedLanguages.includes(newLocale)) {
 		const modulePath = `/src/lang/locale/${newLocale}.ts`
 		const loader = localeModules[modulePath]
 		if (!loader) {
-			console.error(`Locale module not found: ${modulePath}`)
+			logger.error(`Locale module not found: ${modulePath}`)
 			return Promise.resolve(setI18nLanguage(newLocale))
 		}
 		return loader().then((module) => {

--- a/src/model/icon-set.ts
+++ b/src/model/icon-set.ts
@@ -2,6 +2,7 @@ import { defineComponent, h } from 'vue'
 import type { IconSet } from 'vuetify'
 import { mdi as mdiSvgSet } from 'vuetify/iconsets/mdi-svg'
 import { mdiIcons } from './mdi-icons'
+import { logger } from '@/utils/logger'
 
 const VSvgIcon = mdiSvgSet.component
 
@@ -19,7 +20,7 @@ const VMdiSvgIcon = defineComponent({
 			if (typeof raw === 'string') {
 				const path = mdiIcons[raw]
 				if (path) resolved = path
-				else if (import.meta.env.DEV && !raw.startsWith('M')) console.warn('[mdi] unknown icon:', raw)
+				else if (import.meta.env.DEV && !raw.startsWith('M')) logger.warn('[mdi] unknown icon:', raw)
 			}
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				return h(VSvgIcon as any, { ...attrs, tag: props.tag, icon: resolved })

--- a/src/model/leekwars.ts
+++ b/src/model/leekwars.ts
@@ -29,6 +29,7 @@ import { WEAPONS } from './weapons'
 import { BossSquads } from './boss-squads'
 import { DATA_TYPES, loadGameData as loadGameDataRaw } from './gamedata'
 import { nextTick, reactive } from 'vue'
+import { logger } from '@/utils/logger'
 
 const DEV = window.location.port === '8080'
 const LOCAL = window.location.port === '8500' || window.location.port === '5100' || window.location.hostname === 'leekwars.local'
@@ -123,13 +124,13 @@ function request<T = any>(method: string, url: string, params?: string | FormDat
 				} else if (xhr.status === 429 && retry < RETRY_CONFIG.maxRetries) {
 					const delay = retryDelay(retry)
 					if (store.getters.admin || LOCAL || DEV || (window.__FARMER__ && window.__FARMER__.farmer.id === 1)) {
-						console.warn("[429] " + method + " " + url + " — retry " + (retry + 1) + "/" + RETRY_CONFIG.maxRetries + " in " + delay + "ms")
+						logger.warn("[429] " + method + " " + url + " — retry " + (retry + 1) + "/" + RETRY_CONFIG.maxRetries + " in " + delay + "ms")
 					}
 					retryTimeout = setTimeout(() => attempt(retry + 1), delay)
 				} else {
 					if (store.getters.admin || LOCAL || DEV || (window.__FARMER__ && window.__FARMER__.farmer.id === 1)) {
 						const message = "[" + xhr.status + "] " + method + " " + url
-						console.error(message)
+						logger.error(message)
 						// LeekWars.toast(message, 5000)
 					}
 					reject(normalizeApiError(xhr.response))
@@ -139,10 +140,10 @@ function request<T = any>(method: string, url: string, params?: string | FormDat
 				// En dev (cross-origin), une 429 sur le preflight CORS se traduit par un onerror
 				if ((LOCAL || DEV) && retry < RETRY_CONFIG.maxRetries) {
 					const delay = retryDelay(retry)
-					console.warn("[CORS/429?] " + method + " " + url + " — retry " + (retry + 1) + "/" + RETRY_CONFIG.maxRetries + " in " + delay + "ms")
+					logger.warn("[CORS/429?] " + method + " " + url + " — retry " + (retry + 1) + "/" + RETRY_CONFIG.maxRetries + " in " + delay + "ms")
 					retryTimeout = setTimeout(() => attempt(retry + 1), delay)
 				} else {
-					console.error("[429] " + method + " " + url + " — all retries exhausted")
+					logger.error("[429] " + method + " " + url + " — all retries exhausted")
 					LeekWars.toast($t('main.too_many_requests'))
 					reject({ error: 'too_many_requests' })
 				}
@@ -588,7 +589,6 @@ const LeekWars = reactive({
 	isMobile() {
 		return /Mobi/i.test(window.navigator.userAgent)
 		/*
-		// console.log(window.innerWidth, window.innerHeight, window.screen.orientation)
 		const type = (screen.orientation || {}).type || (screen as any).mozOrientation || (screen as any).msOrientation;
 		const angle = (screen.orientation || {}).type || (screen as any).mozOrientation || (screen as any).msOrientation;
 
@@ -915,7 +915,6 @@ const LeekWars = reactive({
 	newVersionPopup: false,
 	displayMessage: (message: string | null) => {
 		if (message) {
-			// console.log("Display message", message)
 			LeekWars.message = message
 			LeekWars.messagePopup = true
 		}
@@ -938,7 +937,6 @@ const LeekWars = reactive({
 	encyclopediaLoaded: {} as {[key: string]: boolean},
 	encyclopediaPromise: {} as {[key: string]: Promise<void>},
 	loadEncyclopedia: (locale: string): Promise<void> => {
-		// console.log("load encyclopedia", locale)
 		if (!LeekWars.encyclopediaLoaded[locale]) {
 			LeekWars.encyclopediaLoaded[locale] = true
 			LeekWars.encyclopediaPromise[locale] = new Promise<void>((resolve) => {
@@ -965,7 +963,6 @@ const LeekWars = reactive({
 	},
 	countries: [] as readonly string[],
 	loadCountries: () => {
-		// console.log("load countries")
 		if (!LeekWars.countries.length) {
 			LeekWars.get<string[]>('country/get-all').then((data) => {
 				LeekWars.countries = Object.freeze(data)
@@ -1009,7 +1006,6 @@ const LeekWars = reactive({
 	},
 	completionsProvider: null as unknown,
 	unload: () => {
-		// console.log("Leek Wars unload")
 		// if (LeekWars.completionsProvider) {
 		// 	LeekWars.completionsProvider.dispose()
 		// }
@@ -1162,7 +1158,6 @@ function weaponByName(weapons: {[key: string]: WeaponTemplate}) {
 	}
 	return result
 }
-
 
 function formatDuration(timestamp: number, capital: boolean = false) {
 
@@ -1379,7 +1374,6 @@ function createCodeAreaSimple(code: string, element: HTMLElement, language?: str
 	})
 }
 
-
 function set_cursor_position(el: HTMLElement, pos: number) {
 	if (!el.firstChild) return
 	const range = document.createRange()
@@ -1430,7 +1424,6 @@ function shadeColor(color: string, amount: number) {
 }
 
 function goToRanking(type: string, order: string, id: number = 0) {
-	// console.log("goToRanking", type, order, id)
 	let url = ''
 	const active = LeekWars.rankingInactive ? '' : '-active'
 	if (type === 'leek') {
@@ -1457,7 +1450,7 @@ function goToRanking(type: string, order: string, id: number = 0) {
  * À appeler au boot de l'app, juste après le mount.
  */
 async function loadGameData() {
-	console.log('[GameData] Loading...')
+	logger.info('[GameData] Loading...')
 	const rawData = await loadGameDataRaw()
 	if (!rawData) {
 		throw new Error('[GameData] No data returned')
@@ -1499,7 +1492,7 @@ async function loadGameData() {
 	if (data.functions) LeekWars.functions = Object.freeze(data.functions)
 	if (data.chips) LeekWars.chips = Object.freeze(data.chips)
 
-	console.log(`[GameData] Applied in ${(performance.now() - t0).toFixed(1)}ms`)
+	logger.info(`[GameData] Applied in ${(performance.now() - t0).toFixed(1)}ms`)
 }
 
 if (DEV || LOCAL) { (window as unknown as Record<string, unknown>).LeekWars = LeekWars }

--- a/src/model/serviceworker.ts
+++ b/src/model/serviceworker.ts
@@ -1,11 +1,12 @@
 import { register } from 'register-service-worker'
+import { logger } from '@/utils/logger'
 
 // Only register service worker in production. Consumers read the active registration via
 // navigator.serviceWorker.ready, so there is no need to stash it here.
 if (import.meta.env.PROD) {
 	register(`${import.meta.env.BASE_URL}service-worker.js`, {
 		error(error) {
-			console.error("Service worker error", error)
+			logger.error("Service worker error", error)
 		},
 	})
 }

--- a/src/model/socket.ts
+++ b/src/model/socket.ts
@@ -4,6 +4,7 @@ import { emitter } from '@/model/emitter'
 import { ChatMessage } from './chat'
 import { NotificationType } from './notification'
 import { store } from './store'
+import { logger } from '@/utils/logger'
 const getAnalyzer = () => import('@/component/editor/analyzer').then(m => m.analyzer)
 
 enum SocketMessage {
@@ -131,10 +132,8 @@ class Socket {
 		}
 		const url = LeekWars.LOCAL ? "ws://localhost:1213/" : (LeekWars.DEV ? "wss://leekwars.com/ws" : "wss://" + window.location.host + "/ws")
 		this.socket = new WebSocket(url, [ 'leek-wars', store.state.token! ])
-		// console.log("[socket] socket", this.socket)
 
 		this.socket.onopen = () => {
-			// console.log("[ws] onopen")
 			store.commit('invalidate-chats')
 			store.commit('wsconnected')
 			this.retry_delay = 1000
@@ -149,12 +148,11 @@ class Socket {
 			this.schedulePing()
 		}
 		this.socket.onclose = () => {
-			// console.log("[ws] onclose")
 			this.clearPing()
 			this.clearPongProbe()
 			if (store.getters.admin || LeekWars.LOCAL || LeekWars.DEV || (window.__FARMER__ && window.__FARMER__.farmer.id === 1)) {
 				const message = "[WS] fermée"
-				console.error(message)
+				logger.error(message)
 				// LeekWars.toast(message, 5000)
 			}
 			store.commit('wsclose')
@@ -165,7 +163,7 @@ class Socket {
 		this.socket.onerror = (event) => {
 			if (store.getters.admin || LeekWars.LOCAL || LeekWars.DEV || (window.__FARMER__ && window.__FARMER__.farmer.id === 1)) {
 				const message = "[WS] erreur"
-				console.error(message, event)
+				logger.error(message, event)
 				// LeekWars.toast(message, 5000)
 			}
 		}
@@ -176,7 +174,6 @@ class Socket {
 			const id = json[0]
 			const data = json[1]
 			const request_id = json[2]
-			// console.log("[WS] onmessage", id, data, request_id)
 
 			emitter.emit('wsmessage', {type: id, data, id: request_id})
 
@@ -248,7 +245,6 @@ class Socket {
 					break
 				}
 				case SocketMessage.CHAT_RECEIVE : {
-					// console.log("socket chat receive", data)
 					const message = data as ChatMessage
 					store.commit('chat-receive', { chat: message.chat, type: data.type, message, new: true })
 					break
@@ -331,7 +327,6 @@ class Socket {
 					break
 				}
 				case SocketMessage.ADD_RESOURCE: {
-					// console.log("add resource", data)
 					const template = data[0]
 					const id = data[1]
 					const quantity = data[2]
@@ -460,7 +455,7 @@ class Socket {
 			this.pongProbeTimeout = setTimeout(() => {
 				this.pongProbeTimeout = null
 				if (store.getters.admin || LeekWars.LOCAL || LeekWars.DEV || (window.__FARMER__ && window.__FARMER__.farmer.id === 1)) {
-					console.warn("[WS] probe timeout, forcing reconnect")
+					logger.warn("[WS] probe timeout, forcing reconnect")
 				}
 				this.reconnect()
 			}, PROBE_RESPONSE_TIMEOUT)
@@ -493,7 +488,7 @@ class Socket {
 	public retry() {
 		if (store.getters.admin || LeekWars.LOCAL || LeekWars.DEV || (window.__FARMER__ && window.__FARMER__.farmer.id === 1)) {
 			const message = "[WS] retry(" + this.retry_delay + "ms)"
-			console.log(message)
+			logger.debug(message)
 		}
 		if (this.intentionallyClosed) { return }
 		if (this.retryTimeout) { clearTimeout(this.retryTimeout) }
@@ -525,7 +520,6 @@ class Socket {
 
 	public send(message: unknown) {
 		if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-			// console.log("[WS] send", message)
 			this.socket.send(JSON.stringify(message))
 		} else {
 			this.queue.push(message)
@@ -537,7 +531,7 @@ class Socket {
 	public disconnect() {
 		if (store.getters.admin || LeekWars.LOCAL || LeekWars.DEV || (window.__FARMER__ && window.__FARMER__.farmer.id === 1)) {
 			const message = "[WS] disconnect()"
-			console.log(message)
+			logger.debug(message)
 		}
 		this.intentionallyClosed = true
 		this.clearPing()

--- a/src/model/store.ts
+++ b/src/model/store.ts
@@ -18,6 +18,7 @@ import { Chip } from './chip'
 import { SchemeTemplate } from './scheme'
 import { Loadout } from './loadout'
 import { NotificationBuilder } from '@/model/notification-builder'
+import { logger } from '@/utils/logger'
 
 // Met à jour (ou ajoute) l'entrée d'un farmer dans chat.farmers à partir d'une version
 // fraîche reçue du serveur, en rafraîchissant les champs d'affichage volatils (#11625).
@@ -227,6 +228,7 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 			LeekWars.arena.reset()
 			LeekWars.bossSquads.leaveSquad()
 			LeekWars.socket.disconnect()
+			// eslint-disable-next-line no-console -- intentional: clear the console on logout
 			console.clear()
 			displayWarningMessage()
 		},
@@ -257,13 +259,11 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 		},
 
 		"wsconnected"(state: LeekWarsState) {
-			// console.log("store wsconnected")
 			state.wsconnected = true
 			state.wsdisconnected = false
 
 			for (const chat of Object.values(state.chat)) {
 				if (chat.opened && !chat.loaded) {
-					// console.log("wsconnected chat", chat.name, chat.opened, chat.loaded)
 					store.commit('register-chat', chat)
 					store.commit('load-chat', chat)
 				}
@@ -302,7 +302,6 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 
 		'reload-chat'(state: LeekWarsState, chat: Chat) {
 			if (chat.loading) return
-			// console.log("load chat", chat, chat.id)
 			state.chat[chat.id].opened = true
 			state.chat[chat.id].loading = true
 			const sequence = chatLoadSequence[chat.id] = (chatLoadSequence[chat.id] || 0) + 1
@@ -361,7 +360,6 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 		},
 
 		'clear-chat'(state: LeekWarsState, chatID: number) {
-			// console.log("clear chat", chatID)
 			const chat = state.chat[chatID]
 			if (chat) {
 				chat.clear()
@@ -379,7 +377,6 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 		'chat-receive'(state: LeekWarsState, data: {chat: number, type: ChatType, message: ChatMessage, new: boolean, unshift: boolean }) {
 
 			if (!state.farmer) return
-			// console.log("chat-receive message", data.chat, data.type, data.message)
 
 			const chatID = data.chat
 			const type = data.type
@@ -624,13 +621,12 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 					LeekWars.squares.addFromNotification(notification)
 				}
 			} catch (e) {
-				console.warn("Failed to build notification", data, e)
+				logger.warn("Failed to build notification", data, e)
 			}
 		},
 
 		'chat-censor'(state: LeekWarsState, data: {chat: number, messages: number[], censorer: Farmer}) {
 			const chat = state.chat[data.chat]
-			// console.log("censor chat", chat)
 			if (chat) {
 				for (const messageID of data.messages) {
 					for (const message of chat.messages) {
@@ -646,7 +642,6 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 
 		'chat-delete'(state: LeekWarsState, data: {chat: number, messages: number[], censorer: Farmer}) {
 			const chat = state.chat[data.chat]
-			// console.log("delete chat", chat, data.messages)
 			if (chat) {
 				for (const message of data.messages) {
 					chat.deleteMessage(message)
@@ -684,7 +679,6 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 		},
 
 		'new-conversation'(state: LeekWarsState, data: { id: number, type?: number, farmers: Farmer[], last_farmer_id: number, last_date: number | null, last_message: string | null, read: boolean }) {
-			// console.log("new-conversation", data)
 			let chat = state.chat[data.id]
 			if (!chat) {
 				const last_farmer = data.farmers.find((f) => f.id === data.last_farmer_id)
@@ -729,7 +723,6 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 
 		'add-inventory'(state: LeekWarsState, data: { type: ItemType, id: number, quantity: number, template: number, time: number }) {
 			if (!state.farmer) { return }
-			// console.log("add-inventory", data)
 			const quantity = data.quantity || 1
 			if (data.type === ItemType.WEAPON) {
 				const weapon = LeekWars.selectWhere(state.farmer.weapons, 'id', data.id)
@@ -829,7 +822,6 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 
 		'remove-inventory'(state: LeekWarsState, data: { type: ItemType, item_template: number, quantity?: number }) {
 			if (!state.farmer) { return }
-			// console.log("remove-inventory", data)
 			const quantity = data.quantity || 1
 			let list: { id: number, template: number, quantity: number }[] | null = null
 			if (data.type === ItemType.WEAPON) {
@@ -1023,7 +1015,6 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 			}
 		},
 
-
 		'set-title'(state: LeekWarsState, title: number[]) {
 			if (state.farmer) {
 				state.farmer.title = title
@@ -1127,7 +1118,6 @@ const store: Store<LeekWarsState> = new Vuex.Store({
 		},
 
 		'add-resource'(state: LeekWarsState, data: { template: number, id: number }) {
-			// console.log("add resource", data);
 			if (state.farmer) {
 				for (const resource of state.farmer.resources) {
 					if (resource.template === data.template) {
@@ -1198,5 +1188,4 @@ function migrateLegacyCacheKeys() {
 	localStorage.setItem(MIGRATION_FLAG, '1')
 }
 queueMicrotask(migrateLegacyCacheKeys)
-
 

--- a/src/model/vue.ts
+++ b/src/model/vue.ts
@@ -604,7 +604,6 @@ const app = createApp({
 			LeekWars.mobile = LeekWars.isMobile()
 		})
 		window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
-			// console.log("Change dark mode", event.matches)
 			if (LeekWars.themeSetting === 'auto') {
 				LeekWars.darkMode = event.matches
 			}
@@ -623,13 +622,11 @@ const app = createApp({
 		startIntervals()
 
 		window.addEventListener('blur', () => {
-			// console.log("onblur")
 			if (secondInterval) clearInterval(secondInterval)
 			if (minuteInterval) clearInterval(minuteInterval)
 			LeekWars.clearIntervals()
 		})
 		window.addEventListener('focus', () => {
-			// console.log("onfocus")
 			emitter.emit('focus')
 			startIntervals()
 			LeekWars.startIntervals()
@@ -685,7 +682,6 @@ const app = createApp({
 
 		emitter.on('loaded', () => {
 			nextTick(() => {
-				// console.log("loaded", this.$data.savedPosition)
 				if (router.currentRoute?.value.hash) {
 					scroll_to_hash(router.currentRoute?.value.hash, router.currentRoute.value)
 				} else if (this.$data.savedPosition > 0) {

--- a/src/router-functions.ts
+++ b/src/router-functions.ts
@@ -4,7 +4,6 @@ import { LeekWars } from "./model/leekwars"
 function scroll_to_hash(hash: string, route: RouteLocationNormalized) {
 	const id = decodeURIComponent(hash).replace(/'/g, '~').substring(1)
 	const element = document.getElementById(id)
-	// console.log("scroll element", id, element, route)
 	if (element) {
 		const offset = (LeekWars.mobile ? 56 : 0) + ((route.meta?.scrollOffset as number) || 0)
 		setTimeout(() => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -304,7 +304,6 @@ const router = createRouter({
 	history: createWebHistory(import.meta.env.BASE_URL),
 	routes,
 	async scrollBehavior(to, from, savedPosition) {
-		// console.log("scrollBehavior", to, from, savedPosition)
 		const vm = vueMain
 		if (vm) {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,44 @@
+/**
+ * Minimal leveled logger, replacing raw console.log calls (#771).
+ * In production only warnings and errors are emitted; in development
+ * everything is, so logger.debug/info are free to use while coding.
+ */
+export enum LogLevel {
+	DEBUG = 0,
+	INFO = 1,
+	WARN = 2,
+	ERROR = 3,
+	NONE = 4,
+}
+
+/* eslint-disable no-console */
+class Logger {
+	level: LogLevel = import.meta.env.PROD ? LogLevel.WARN : LogLevel.DEBUG
+
+	debug(message?: unknown, ...args: unknown[]) {
+		if (this.level <= LogLevel.DEBUG) {
+			console.debug(message, ...args)
+		}
+	}
+
+	info(message?: unknown, ...args: unknown[]) {
+		if (this.level <= LogLevel.INFO) {
+			console.info(message, ...args)
+		}
+	}
+
+	warn(message?: unknown, ...args: unknown[]) {
+		if (this.level <= LogLevel.WARN) {
+			console.warn(message, ...args)
+		}
+	}
+
+	error(message?: unknown, ...args: unknown[]) {
+		if (this.level <= LogLevel.ERROR) {
+			console.error(message, ...args)
+		}
+	}
+}
+/* eslint-enable no-console */
+
+export const logger = new Logger()


### PR DESCRIPTION
Closes #771

Implements the logger proposed in the issue:

- **`src/utils/logger.ts`** — `debug`/`info`/`warn`/`error` with `LogLevel`; production emits WARN+, development emits everything (`import.meta.env.PROD`)
- **Deleted** 140 commented-out `console.log` lines and 6 temporary debug logs ("save...", schemes dumps, socket console echoes)
- **Converted** the remaining active calls by category: `[GameData]` load events → `logger.info`, dev diagnostics → `logger.debug`, anomalies (`console.trace`, drawable-element warnings) → `logger.warn`, `console.warn`/`console.error` → `logger.warn`/`logger.error`
- **Kept intentionally**: the styled player-facing devtools warning in `emitter.ts` and `console.clear()` on logout — both annotated with `eslint-disable` comments explaining why they must stay raw
- **ESLint**: added `'no-console': ['error', { allow: ['warn', 'error'] }]` with an override for `*.test.ts`

Verification: `eslint src` passes with no `no-console`/`no-empty` violations; `vue-tsc --noEmit` reports no errors in any touched file (the 12 remaining errors are pre-existing on master, all in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)